### PR TITLE
stream instead of list

### DIFF
--- a/spacy_llm/registry/template.py
+++ b/spacy_llm/registry/template.py
@@ -13,6 +13,7 @@ def noop_template() -> Callable[[Iterable[Doc]], Iterable[str]]:
     template = "Don't do anything."
 
     def prompt_template(docs: Iterable[Doc]) -> Iterable[str]:
-        return [template]
+        for doc in docs:
+            yield template
 
     return prompt_template


### PR DESCRIPTION

## Description
* `spacy.template.NoOp.v1` should return as many templates as there are docs
* yield stream instead of returning a list

### Types of change
fix

## Checklist
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
