### PR TITLE
Fix external test bug due to saving to disk

### DIFF
--- a/spacy_llm/backends/langchain.py
+++ b/spacy_llm/backends/langchain.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Dict, Iterable, Type
+from typing import Any, Callable, Dict, Iterable, Optional, Type
 from typing import TYPE_CHECKING
 
 from spacy.util import SimpleFrozenDict
@@ -36,7 +36,7 @@ def query_langchain() -> Callable[["BaseLLM", Iterable[str]], Iterable[str]]:
 @registry.llm_backends("spacy.LangChain.v1")
 def backend_langchain(
     api: str,
-    query: Callable[["BaseLLM", Iterable[str]], Iterable[str]] = query_langchain(),
+    query: Optional[Callable[["BaseLLM", Iterable[str]], Iterable[str]]] = None,
     config: Dict[Any, Any] = SimpleFrozenDict(),
 ) -> Callable[[Iterable[Any]], Iterable[Any]]:
     """Returns Callable using MiniChain backend to prompt specified API.
@@ -58,8 +58,10 @@ def backend_langchain(
     if api in type_to_cls_dict:
         backend = type_to_cls_dict[api](**config)
 
+        query_fn = query_langchain() if query is None else query
+
         def _query(prompts: Iterable[Any]) -> Iterable[Any]:
-            return query(backend, prompts)
+            return query_fn(backend, prompts)
 
         return _query
     else:


### PR DESCRIPTION
The problem is that the query parameter of the backend is initialized with a function, this causes a config with a function inside, preventing us to saving properly to disk (invalid JSON/config).



## Description

My hacky solution is to make this value pseudo-optional where the default is None, yet the default value for the query is assigned when that's the case (`query_minichain`, `query_langchain`).

Here's what the faulty config looks like. Notice the function in minichain:

```python
 "components":{
      "llm":{
         "factory":"llm",
         "backend":{
            "@llm_backends":"spacy.MiniChain.v1",
            "api":"OpenAI",
            "config":{

            },
            "query":<function query_minichain.<locals>.prompt at 0x7f011e10d160>
         },
         "cache":{
            "path":"None",
            "batch_size":64,
            "max_batches_in_mem":4
         },
         "task":{
            "@llm_tasks":"spacy.NERZeroShot.v1",
            "labels":"PER,ORG,LOC",
            "normalizer":{
               "@misc":"spacy.LowercaseNormalizer.v1"
            },
            "alignment_mode":"contract",
            "case_sensitive_matching":false,
            "single_match":false
         }
      }
   },
```


### Types of change

Bugfix

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
