### PR TITLE
Add manual trigger to external.yml

### DIFF
--- a/.github/workflows/external.yml
+++ b/.github/workflows/external.yml
@@ -1,6 +1,7 @@
 name: External tests
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: "0 0 * * *"
 


### PR DESCRIPTION
Add option to manually trigger a workflow so we can always check if external tests will work.

For the manually triggering issue:
- Here's the PR https://github.com/explosion/spacy-llm/pull/41
- Just to confirm, spaCy is also doing something similar for the [Lock threads workflow](https://github.com/explosion/spaCy/blob/15f16db6ca3fd10a9667358d2f7b7e6eaf967e0a/.github/workflows/lock.yml#L6), but when I look at the Action, there's no manual trigger button. My guess is that it's just a permissions thing 🤔 



## Description

Based from GH documentation: https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow
More docs here:
- https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/

### Types of change

- Chore, update to CI

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [ ] I ran the tests, and all new and existing tests passed.
- [ ] My changes don't require a change to the documentation, or if they do, I've added all required information.
