### PR TITLE
add external tag to cache test

### DIFF
--- a/spacy_llm/tests/test_cache.py
+++ b/spacy_llm/tests/test_cache.py
@@ -21,6 +21,7 @@ _DEFAULT_CFG = {
 }
 
 
+@pytest.mark.external
 def test_caching() -> None:
     """Test pipeline with caching."""
     n = 10


### PR DESCRIPTION

## Description
Found one more test that had the `@pytest.mark.external` marker missing.

### Types of change

## Checklist
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
