### PR TITLE
avoid imports and errors if Dolly is not actually used

### DIFF
--- a/spacy_llm/backends/dolly.py
+++ b/spacy_llm/backends/dolly.py
@@ -1,7 +1,7 @@
 import warnings
 from typing import Any, Callable, Dict, Iterable
 
-from spacy.util import SimpleFrozenList
+from spacy.util import SimpleFrozenList, SimpleFrozenDict
 from thinc.compat import has_torch_cuda_gpu
 
 from ..compat import has_accelerate, has_torch, has_transformers, torch, transformers
@@ -11,31 +11,6 @@ from ..registry.util import registry
 supported_models = SimpleFrozenList(
     ["databricks/dolly-v2-3b", "databricks/dolly-v2-7b", "databricks/dolly-v2-12b"]
 )
-
-_DEFAULT_CFG: Dict[str, Any] = {
-    # Loads a custom pipeline from https://huggingface.co/databricks/dolly-v2-3b/blob/main/instruct_pipeline.py
-    # cf also https://huggingface.co/databricks/dolly-v2-12b
-    "trust_remote_code": True,
-}
-
-if has_torch:
-    _DEFAULT_CFG["torch_dtype"] = torch.bfloat16
-    if has_torch_cuda_gpu:
-        # this ensures it fails explicitely when GPU is not enabled or sufficient
-        _DEFAULT_CFG["device"] = "cuda:0"
-    elif has_accelerate:
-        # accelerate will distribute the layers depending on availability on GPU/CPU/hard drive
-        _DEFAULT_CFG["device_map"] = "auto"
-        warnings.warn(
-            "Couldn't find a CUDA GPU, so the setting 'device_map:auto' will be used, which may result "
-            "in the LLM being loaded (partly) on the CPU or even the hard disk, which may be slow. "
-            "Install cuda to be able to load and run the LLM on the GPU instead."
-        )
-    else:
-        raise ValueError(
-            "Install CUDA to load and run the LLM on the GPU, or install 'accelerate' to dynamically "
-            "distribute the LLM on the CPU or even the hard disk. The latter may be slow."
-        )
 
 
 def _check_installation() -> None:
@@ -59,10 +34,38 @@ def _check_model(model: str) -> None:
         )
 
 
+def _compile_default_config() -> Dict[Any, Any]:
+    default_cfg: Dict[str, Any] = {
+        # Loads a custom pipeline from https://huggingface.co/databricks/dolly-v2-3b/blob/main/instruct_pipeline.py
+        # cf also https://huggingface.co/databricks/dolly-v2-12b
+        "trust_remote_code": True,
+    }
+
+    if has_torch:
+        default_cfg["torch_dtype"] = torch.bfloat16
+        if has_torch_cuda_gpu:
+            # this ensures it fails explicitely when GPU is not enabled or sufficient
+            default_cfg["device"] = "cuda:0"
+        elif has_accelerate:
+            # accelerate will distribute the layers depending on availability on GPU/CPU/hard drive
+            default_cfg["device_map"] = "auto"
+            warnings.warn(
+                "Couldn't find a CUDA GPU, so the setting 'device_map:auto' will be used, which may result "
+                "in the LLM being loaded (partly) on the CPU or even the hard disk, which may be slow. "
+                "Install cuda to be able to load and run the LLM on the GPU instead."
+            )
+        else:
+            raise ValueError(
+                "Install CUDA to load and run the LLM on the GPU, or install 'accelerate' to dynamically "
+                "distribute the LLM on the CPU or even the hard disk. The latter may be slow."
+            )
+    return default_cfg
+
+
 @registry.llm_backends("spacy.DollyHF.v1")
 def backend_dolly_hf(
     model: str,
-    config: Dict[Any, Any] = _DEFAULT_CFG,
+    config: Dict[Any, Any] = SimpleFrozenDict(),
 ) -> Callable[[Iterable[str]], Iterable[str]]:
     """Returns Callable that can execute a set of prompts and return the raw responses.
     model (str): Name of the HF model.
@@ -71,6 +74,10 @@ def backend_dolly_hf(
     """
     _check_installation()
     _check_model(model)
+
+    if not config or len(config) == 0:
+        config = _compile_default_config()
+
     llm_pipeline = transformers.pipeline(model=model, **config)
 
     def query(prompts: Iterable[str]) -> Iterable[str]:


### PR DESCRIPTION

## Description
Moving code around so that a default config for Dolly is not compiled (and errors not raised) until you actually use Dolly 🐑 

### Types of change
bug fix

## Checklist
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
