### PR TITLE
strip response so binary textcat works

### DIFF
--- a/spacy_llm/tasks/textcat.py
+++ b/spacy_llm/tasks/textcat.py
@@ -137,6 +137,7 @@ Text:
         The returned dictionary contains the labels mapped to their score.
         """
         categories: Dict[str, float]
+        response = response.strip()
         if self._use_binary:
             # Binary classification: We only have one label
             label: str = list(self._label_dict.values())[0]

--- a/spacy_llm/tests/tasks/test_textcat.py
+++ b/spacy_llm/tests/tasks/test_textcat.py
@@ -199,6 +199,8 @@ def test_textcat_sets_exclusive_classes_if_binary():
         ("Some test text with weird response", "WeIrD OUtpuT", 0.0),
         ("Some test text with lowercase response", "pos", 1.0),
         ("Some test text with lowercase response", "neg", 0.0),
+        ("Some test text with unstripped response", "\n\n\nPOS", 1.0),
+        ("Some test text with unstripped response", "\n\n\nNEG", 0.0),
     ],
 )
 def test_textcat_binary_labels_are_correct(text, response, expected_score):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

The way our textcat prompt is setup, the LLM (at least OpenAI API) will return a response with `\n\n` at the beginning.

So we get e.g. `\n\nPOS` for binary classification but we aren't stripping the response. So currently we'll always get a 0.0 classification for binary textcat (1 label and exclusive_classes = True)

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

bug fix

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
