### PR TITLE
WIP: Explore using the PhraseMatcher for find_substrings

### DIFF
--- a/spacy_llm/tasks/ner.py
+++ b/spacy_llm/tasks/ner.py
@@ -35,8 +35,8 @@ def find_substrings(
     matches: List[Span] = matcher(doc, as_spans=True)
 
     def _filter_first_hit(matches: List[Span]) -> Iterable[Tuple[int, int]]:
-        seen_spans = []
-        filtered = []
+        seen_spans: List[Span] = []
+        filtered: List[Span] = []
         for match in matches:
             start, end = match.start_char, match.end_char
             span_text = doc.char_span(start, end).text

--- a/spacy_llm/tests/tasks/test_ner.py
+++ b/spacy_llm/tests/tasks/test_ner.py
@@ -149,9 +149,9 @@ def test_ensure_offsets_correspond_to_substrings(
     offsets = find_substrings(text, input_strings)
     # Compare strings instead of offsets, but we need to get
     # those strings first from the text
-    assert result_offsets == offsets
+    assert sorted(result_offsets) == sorted(offsets)
     found_substrings = [text[start:end] for start, end in offsets]
-    assert result_strings == found_substrings
+    assert sorted(result_strings) == sorted(found_substrings)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR attempts to rewrite the `find_substrings` function with the [PhraseMatcher](https://spacy.io/api/phrasematcher). Almost all of our options like case-sensitivity and matching can be replicated, except the `single_match` toggle. I implemented it naively by keeping track of seen `span.text`s and adding it to the final `offsets` output.


## Description

There are some behavioural changes with this approach. I made sure to document them in the tests below:

- The substrings will now appear as they're sorted by `PhraseMatcher`. At first, this causes some of our existing tests to fail. But I update them in ae49c04
- Partial substrings won't be matched anymore. Normally, a text that says:
 
```python
text = "Frodo Baggins and Samwise Gamgee went to Mt. Doom"
llm_predictions = "PER: Frodo B. Samwise G"
# Before
find_substrings_main_branch(text, substrings=llm_predictions)  # returns ["Frodo", "Samwise"]
# In this PR
find_substrings_this_branch(text, substrings=llm_predictions)  # returns []
```

Will be matched by using the `expand` option in the existing implementation. But in this case, the `PhraseMatcher` won't be able to find them. And it will return an empty list. You'll notice this behaviour in the **currently failing tests** in the CI. I didn't change the existing test here because I want to document that change in behaviour.

- The `spacy.NER.v1` task now takes in an optional `lang: str = "xx"` parameter that will be used to initialize the `PhraseMatcher`.

### Final thoughts

I don't mind sticking to the `find_substrings` option. I'm still looking for ways to solve the above issue.


### Types of change

- Refactor + Optimization
- Exploration
- New tests reflecting this update

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [ ] I ran the tests, and all new and existing tests passed.
- [ ] My changes don't require a change to the documentation, or if they do, I've added all required information.
