### PR TITLE
Use Path.is_dir() instead of os.path

### DIFF
--- a/spacy_llm/cache.py
+++ b/spacy_llm/cache.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 from typing import Dict, Union, Optional, Iterable, List
 
@@ -56,7 +55,7 @@ class Cache:
         if self._path is None:
             return
 
-        if self._path.exists() and not os.path.isdir(self._path):
+        if self._path.exists() and not self._path.is_dir():
             raise ValueError("Cache directory exists and is not a directory.")
         self._path.mkdir(parents=True, exist_ok=True)
 


### PR DESCRIPTION
Minimal imports and take advantage of the Path type.

<!--- Provide a general summary of your changes in the title. -->

## Description

Small PR that uses `Path.is_dir()` instead of `os.path` for minimal imports.


### Types of change

Minor refactor

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
