### PR TITLE
improve textcat task by better constraining its output and giving a more detailed task intro

### DIFF
--- a/spacy_llm/tasks/textcat.py
+++ b/spacy_llm/tasks/textcat.py
@@ -16,18 +16,25 @@ class TextCatExample(BaseModel):
 @registry.llm_tasks("spacy.TextCat.v1")
 class TextCatTask:
     _TEMPLATE_STR = """
+You are an expert Text Classification system. Your task is to accept Text as input
+and provide a category for the text based on the predefined labels.
+{# whitespace #}
+{# whitespace #}
 {%- if labels|length == 1 -%}
 {%- set label = labels[0] -%}
 Classify whether the text below belongs to the {{ label }} category or not.
 If it is a {{ label }}, answer `POS`. If it is not a {{ label }}, answer `NEG`.
+Do not put any other text in your answer, only one of 'POS' or 'NEG' with nothing before or after.
 {%- else -%}
 Classify the text below to any of the following labels: {{ labels|join(", ") }}
 {# whitespace #}
 {%- if exclusive_classes -%}
 The task is exclusive, so only choose one label from what I provided.
+Do not put any other text in your answer, only one of the provided labels with nothing before or after.
 {%- else -%}
 The task is non-exclusive, so you can provide more than one label as long as
 they're comma-delimited. For example: Label1, Label2, Label3.
+Do not put any other text in your answer, only one or more of the provided labels with nothing before or after.
 {%- if allow_none -%}
 {# whitespace #}
 If the text cannot be classified into any of the provided labels, answer `==NONE==`.

--- a/spacy_llm/tests/tasks/test_textcat.py
+++ b/spacy_llm/tests/tasks/test_textcat.py
@@ -280,8 +280,12 @@ def test_jinja_template_rendering_with_examples_for_binary(examples_path, binary
     assert (
         prompt.strip()
         == """
+You are an expert Text Classification system. Your task is to accept Text as input
+and provide a category for the text based on the predefined labels.
+
 Classify whether the text below belongs to the Recipe category or not.
 If it is a Recipe, answer `POS`. If it is not a Recipe, answer `NEG`.
+Do not put any other text in your answer, only one of 'POS' or 'NEG' with nothing before or after.
 Below are some examples (only use these as a guide):
 
 
@@ -342,8 +346,12 @@ def test_jinja_template_rendering_with_examples_for_multilabel_exclusive(
     assert (
         prompt.strip()
         == """
+You are an expert Text Classification system. Your task is to accept Text as input
+and provide a category for the text based on the predefined labels.
+
 Classify the text below to any of the following labels: Recipe, Feedback, Comment
 The task is exclusive, so only choose one label from what I provided.
+Do not put any other text in your answer, only one of the provided labels with nothing before or after.
 Below are some examples (only use these as a guide):
 
 
@@ -404,9 +412,13 @@ def test_jinja_template_rendering_with_examples_for_multilabel_nonexclusive(
     assert (
         prompt.strip()
         == """
-    Classify the text below to any of the following labels: Recipe, Feedback, Comment
+You are an expert Text Classification system. Your task is to accept Text as input
+and provide a category for the text based on the predefined labels.
+
+Classify the text below to any of the following labels: Recipe, Feedback, Comment
 The task is non-exclusive, so you can provide more than one label as long as
 they're comma-delimited. For example: Label1, Label2, Label3.
+Do not put any other text in your answer, only one or more of the provided labels with nothing before or after.
 If the text cannot be classified into any of the provided labels, answer `==NONE==`.
 Below are some examples (only use these as a guide):
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

The switch to `gpt-3.5-turbo` as the default model seems to make the LLM lean toward providing a longer output (not necessarily constrained to a single label).

e.g. 

for the text:

```
"you are quite beautiful"
```

the LLM response from `gpt-3.5-turbo` for binary classification was:

```
COMPLIMENT (POS)
```

The LLM got this right but not in a way we can parse. 

This PR adds a longer intro, similar to the new NER intro in: #84 as well as language to tell the model it's important not to return anything else but the labels we want for each kind of classification.

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

fix/enhancement

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests (including the **external** tests), and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
