### PR TITLE
fix response of openai chat endpoint

### DIFF
--- a/spacy_llm/backends/rest/backend/openai.py
+++ b/spacy_llm/backends/rest/backend/openai.py
@@ -132,11 +132,11 @@ class OpenAIBackend(Backend):
                 # Process responses.
                 assert len(responses["choices"]) == 1
                 response = responses["choices"][0]
-                api_responses = [
+                api_responses.append(
                     response.get("message", {}).get(
                         "content", srsly.json_dumps(response)
                     )
-                ]
+                )
 
         elif url == Endpoints.non_chat:
             responses = _request({"prompt": prompts})

--- a/spacy_llm/tests/backends/test_rest.py
+++ b/spacy_llm/tests/backends/test_rest.py
@@ -12,7 +12,7 @@ PIPE_CFG = {
         "api": "OpenAI",
         "config": {"temperature": 0.3, "model": "gpt-3.5-turbo"},
     },
-    "task": {"@llm_tasks": "spacy.NoOp.v1"},
+    "task": {"@llm_tasks": "spacy.TextCat.v1", "labels": "POSITIVE,NEGATIVE"},
 }
 
 
@@ -60,7 +60,10 @@ def test_openai(model: str):
         config=cfg,
     )
     nlp("test")
-    assert len(list(nlp.pipe(["test 1", "test 2"]))) == 2
+    docs = list(nlp.pipe(["test 1", "test 2"]))
+    assert len(docs) == 2
+    assert docs[0].text == "test 1"
+    assert docs[1].text == "test 2"
 
 
 @pytest.mark.skipif(has_openai_key is False, reason="OpenAI API key not available")


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

PR https://github.com/explosion/spacy-llm/pull/96 introduced a bug that wasn't caught in our tests due to using a Noop Task.

[This line](https://github.com/explosion/spacy-llm/blob/8279f6764cb56a0d0f6a809e1c436856c939ed0b/spacy_llm/backends/rest/backend/openai.py#LL135C5-L135C5) overwrites the `api_responses` variable so if multiple prompts are sent, only 1 response is returned (the last in the list). 

Fixing by using `append` and using the `TextCat` task instead of Noop so the docs/responses are actually used and tested.

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

fix

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests (including the **external** tests), and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
