### PR TITLE
fix: use v2 textcat for ext template tests

### DIFF
--- a/spacy_llm/tests/tasks/test_textcat.py
+++ b/spacy_llm/tests/tasks/test_textcat.py
@@ -93,7 +93,7 @@ def ext_template_cfg_string():
     factory = "llm"
 
     [components.llm.task]
-    @llm_tasks = "spacy.TextCat.v1"
+    @llm_tasks = "spacy.TextCat.v2"
     labels = "Recipe"
     exclusive_classes = true
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

The external textcat tests weren't working with the new template since it used the v1 textcat task. This gets all external tests green again

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

bug fix

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran all tests , and all new and existing tests passed. This includes tests marked as `external` and those 
  requiring a GPU. I did this for the following directories:
  - [x] `tests`
  - [x] `usage_example/tests`
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
