### PR TITLE
Fix duplicate spacy.TextCat.v1 section

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,54 +524,6 @@ labels = COMPLIMENT,INSULT
 path = "textcat_examples.json"
 ```
 
-#### spacy.TextCat.v1
-
-The original version of the built-in TextCat task supports both zero-shot and few-shot prompting.
-
-```ini
-[components.llm.task]
-@llm_tasks = "spacy.TextCat.v1"
-labels = COMPLIMENT,INSULT
-examples = null
-```
-
-| Argument            | Type                                    | Default              | Description                                                                                                                                      |
-| ------------------- | --------------------------------------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `labels`            | str                                     |                      | Comma-separated list of labels.                                                                                                                  |
-| `examples`          | `Optional[Callable[[], Iterable[Any]]]` | `None`               | Optional function that generates examples for few-shot learning.                                                                                 |
-| `normalizer`        | `Optional[Callable[[str], str]]`        | `None`               | Function that normalizes the labels as returned by the LLM. If `None`, falls back to `spacy.LowercaseNormalizer.v1`.                             |
-| `exclusive_classes` | `bool`                                  | `False`              | If set to `True`, only one label per document should be valid. If set to `False`, one document can have multiple labels.                         |
-| `allow_none`        | `bool`                                  | `True`               | When set to `True`, allows the LLM to not return any of the given label. The resulting dict in `doc.cats` will have `0.0` scores for all labels. |
-| `verbose`           | `bool`                                  | `False`              | If set to `True`, warnings will be generated when the LLM returns invalid responses.                                                             |
-
-
-[textcat]: https://github.com/explosion/spacy-llm/blob/main/spacy_llm/tasks/textcat.py#L13
-
-To perform few-shot learning, you can write down a few examples in a separate file, and provide these to be injected into the prompt to the LLM.
-The default reader `spacy.FewShotReader.v1` supports `.yml`, `.yaml`, `.json` and `.jsonl`.
-
-```json
-[
-  {
-    "text": "You look great!",
-    "answer": "Compliment"
-  },
-  {
-    "text": "You are not very clever at all.",
-    "answer": "Insult"
-  }
-]
-```
-
-```ini
-[components.llm.task]
-@llm_tasks = "spacy.TextCat.v1"
-labels = COMPLIMENT,INSULT
-[components.llm.task.examples]
-@misc = "spacy.FewShotReader.v1"
-path = "textcat_examples.json"
-```
-
 #### spacy.REL.v1
 
 The built-in REL task supports both zero-shot and few-shot prompting.


### PR DESCRIPTION
The `spacy.TextCat.v1` section seems to be duplicate. Minor documentation fix.


### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

- Doc fix

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran all tests , and all new and existing tests passed. This includes tests marked as `external` and those 
  requiring a GPU. I did this for the following directories:
  - [x] `tests`
  - [x] `usage_example/tests`
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
