### PR TITLE
specify config_path as Union[str, Path]

### DIFF
--- a/usage_examples/multitask_openai/run_pipeline.py
+++ b/usage_examples/multitask_openai/run_pipeline.py
@@ -14,7 +14,7 @@ Opt = typer.Option
 def run_pipeline(
     # fmt: off
     text: str = Arg("", help="Text to perform text categorization on."),
-    config_path: Path = Arg(..., help="Path to the configuration file to use."),
+    config_path: Union[str, Path] = Arg(..., help="Path to the configuration file to use."),
     examples_path: Optional[Path] = Arg(None, help="Path to the examples file to use (few-shot only)."),
     verbose: bool = Opt(False, "--verbose", "-v", help="Show extra information."),
     # fmt: on

--- a/usage_examples/ner_dolly/run_pipeline.py
+++ b/usage_examples/ner_dolly/run_pipeline.py
@@ -13,7 +13,7 @@ Opt = typer.Option
 def run_pipeline(
     # fmt: off
     text: str = Arg("", help="Text to perform Named Entity Recognition on."),
-    config_path: Path = Arg(..., help="Path to the configuration file to use."),
+    config_path: Union[str, Path] = Arg(..., help="Path to the configuration file to use."),
     examples_path: Optional[Path] = Arg(None, help="Path to the examples file to use (few-shot only)."),
     verbose: bool = Opt(False, "--verbose", "-v", help="Show extra information."),
     # fmt: on

--- a/usage_examples/ner_langchain_openai/run_pipeline.py
+++ b/usage_examples/ner_langchain_openai/run_pipeline.py
@@ -13,7 +13,7 @@ Opt = typer.Option
 def run_pipeline(
     # fmt: off
     text: str = Arg("", help="Text to perform NER on."),
-    config_path: Path = Arg(..., help="Path to the configuration file to use."),
+    config_path: Union[str, Path] = Arg(..., help="Path to the configuration file to use."),
     verbose: bool = Opt(False, "--verbose", "-v", help="Show extra information."),
     # fmt: on
 ):

--- a/usage_examples/ner_minichain_openai/run_pipeline.py
+++ b/usage_examples/ner_minichain_openai/run_pipeline.py
@@ -13,7 +13,7 @@ Opt = typer.Option
 def run_pipeline(
     # fmt: off
     text: str = Arg("", help="Text to perform NER on."),
-    config_path: Path = Arg(..., help="Path to the configuration file to use."),
+    config_path: Union[str, Path] = Arg(..., help="Path to the configuration file to use."),
     verbose: bool = Opt(False, "--verbose", "-v", help="Show extra information."),
     # fmt: on
 ):

--- a/usage_examples/rel_openai/run_pipeline.py
+++ b/usage_examples/rel_openai/run_pipeline.py
@@ -14,7 +14,7 @@ Opt = typer.Option
 def run_pipeline(
     # fmt: off
     text: str = Arg("", help="Text to perform text categorization on."),
-    config_path: Path = Arg(..., help="Path to the configuration file to use."),
+    config_path: Union[str, Path] = Arg(..., help="Path to the configuration file to use."),
     examples_path: Optional[Path] = Arg(None, help="Path to the examples file to use (few-shot only)."),
     verbose: bool = Opt(False, "--verbose", "-v", help="Show extra information."),
     # fmt: on

--- a/usage_examples/textcat_openai/run_pipeline.py
+++ b/usage_examples/textcat_openai/run_pipeline.py
@@ -14,7 +14,7 @@ Opt = typer.Option
 def run_pipeline(
     # fmt: off
     text: str = Arg("", help="Text to perform text categorization on."),
-    config_path: Path = Arg(..., help="Path to the configuration file to use."),
+    config_path: Union[str, Path] = Arg(..., help="Path to the configuration file to use."),
     examples_path: Optional[Path] = Arg(None, help="Path to the examples file to use (few-shot only)."),
     verbose: bool = Opt(False, "--verbose", "-v", help="Show extra information."),
     # fmt: on


### PR DESCRIPTION

## Description
These scripts are in the example usages dir, so it'd be good if they reflect the actual correct type from the `assemble` functionality in case users are copy/pasting etc.

### Types of change
fix

## Checklist
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran all tests in `tests` and `usage_examples/tests`, and all new and existing tests passed. This includes
  - all external tests (i. e. `pytest` ran with `--external`)
  - all tests requiring a GPU
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
