### PR TITLE
clean up assemble to call assemble_from_config

### DIFF
--- a/spacy_llm/util.py
+++ b/spacy_llm/util.py
@@ -20,6 +20,7 @@ def split_labels(labels: Union[str, Iterable[str]]) -> List[str]:
 
 def assemble_from_config(config: Config) -> Language:
     """Assemble a spaCy pipeline from a confection Config object.
+
     config (Config): Config to load spaCy pipeline from.
     RETURNS (Language): An initialized spaCy pipeline.
     """
@@ -36,6 +37,7 @@ def assemble(
     config_path: Union[str, Path], *, overrides: Dict[str, Any] = SimpleFrozenDict()
 ) -> Language:
     """Assemble a spaCy pipeline from a config file.
+
     config_path (Union[str, Path]): Path to config file.
     overrides (Dict[str, Any], optional): Dictionary of config overrides.
     RETURNS (Language): An initialized spaCy pipeline.

--- a/spacy_llm/util.py
+++ b/spacy_llm/util.py
@@ -2,6 +2,7 @@ from typing import Any, Dict, Iterable, List, Union
 from pathlib import Path
 
 from confection import Config
+from spacy.language import Language
 from spacy.util import SimpleFrozenDict, get_sourced_components, load_config
 from spacy.util import load_model_from_config
 
@@ -17,9 +18,11 @@ def split_labels(labels: Union[str, Iterable[str]]) -> List[str]:
     return [label.strip() for label in labels]
 
 
-def assemble_from_config(
-    config: Config,
-):
+def assemble_from_config(config: Config) -> Language:
+    """Assemble a spaCy pipeline from a confection Config object.
+    config (Config): Config to load spaCy pipeline from.
+    RETURNS (Language): An initialized spaCy pipeline.
+    """
     nlp = load_model_from_config(config, auto_fill=True)
     config = config.interpolate()
     sourced = get_sourced_components(config)
@@ -30,16 +33,13 @@ def assemble_from_config(
 
 
 def assemble(
-    config_path: Union[str, Path],
-    *,
-    overrides: Dict[str, Any] = SimpleFrozenDict(),
-):
+    config_path: Union[str, Path], *, overrides: Dict[str, Any] = SimpleFrozenDict()
+) -> Language:
+    """Assemble a spaCy pipeline from a config file.
+    config_path (Union[str, Path]): Path to config file.
+    overrides (Dict[str, Any], optional): Dictionary of config overrides.
+    RETURNS (Language): An initialized spaCy pipeline.
+    """
     config_path = Path(config_path)
     config = load_config(config_path, overrides=overrides, interpolate=False)
-    nlp = load_model_from_config(config, auto_fill=True)
-    config = config.interpolate()
-    sourced = get_sourced_components(config)
-    nlp._link_components()
-    with nlp.select_pipes(disable=[*sourced]):
-        nlp.initialize()
-    return nlp
+    return assemble_from_config(config)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

We have some duplicated code between `assemble` and `assemble_from_config`. Seems nice consolidate this logic and have `assemble` just load config and then call into `assemble_from_config`. Also adding basic docstrings

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

Refactor

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran all tests in `tests` and `usage_examples/tests`, and all new and existing tests passed. This includes
  - all external tests (i. e. `pytest` ran with `--external`)
  - all tests requiring a GPU
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
