### PR TITLE
Use equality operator in tests

### DIFF
--- a/spacy_llm/ty.py
+++ b/spacy_llm/ty.py
@@ -169,7 +169,7 @@ def validate_types(task: LLMTask, backend: PromptExecutor) -> None:
     for k in type_hints["parse"]:
         # find the 'prompt_responses' var without assuming its name
         type_k = type_hints["parse"][k]
-        if type_k is not typing.Iterable[Doc]:
+        if type_k != typing.Iterable[Doc]:
             parse_input = type_hints["parse"][k]
 
     template_output = type_hints["template"]["return"]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
Most of the test suite fails on some machines when checking types - a comparison with `is` consistently returns `False` even if the types are the same. This PR fixes that. 

### Types of change
Bug fix.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran all tests in `tests` and `usage_examples/tests`, and all new and existing tests passed. This includes
  - all external tests (i. e. `pytest` ran with `--external`)
  - all tests requiring a GPU
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
