### PR TITLE
Bumping version id to prompt pypi update

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-version = 0.2.0
+version = 0.2.1
 description = Integrating LLMs into structured NLP pipelines
 author = Explosion
 author_email = contact@explosion.ai


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->
As outlined in this issue [here](https://github.com/explosion/spaCy/issues/12695) it seems like the pypi version is outdated. I assume the simple solution is to bump the version number which will prompt a version update.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [ ] I ran all tests in `tests` and `usage_examples/tests`, and all new and existing tests passed. This includes
  - all external tests (i. e. `pytest` ran with `--external`)
  - all tests requiring a GPU
- [x] My changes don't require a change to the documentation, or if they do, I've added all the required information.
