### PR TITLE
Fix issue with blank prompts

### DIFF
--- a/spacy_llm/pipeline/llm.py
+++ b/spacy_llm/pipeline/llm.py
@@ -148,9 +148,14 @@ class LLMWrapper(Pipe):
         """
         is_cached = [doc in self._cache for doc in docs]
         noncached_doc_batch = [doc for i, doc in enumerate(docs) if not is_cached[i]]
-        prompts = self._task.generate_prompts(noncached_doc_batch)
-        responses = self._backend(prompts)
-        modified_docs = iter(self._task.parse_responses(noncached_doc_batch, responses))
+        modified_docs = iter(())
+        if noncached_doc_batch:
+            prompts = self._task.generate_prompts(noncached_doc_batch)
+            responses = self._backend(prompts)
+            modified_docs = iter(
+                self._task.parse_responses(noncached_doc_batch, responses)
+            )
+
         final_docs = []
         for i, doc in enumerate(docs):
             if is_cached[i]:


### PR DESCRIPTION
## Description
I'm not sure if this is an issue for every kind of model, but at least with `text-davinci-003`, loading from a cache fails because you're still attempting to parse the non-cached examples in a batch - if this list is empty, the model receives a blank prompt and exits, this should fix that by explicitly checking.

### Types of change
Bug fix.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran all tests in `tests` and `usage_examples/tests`, and all new and existing tests passed. This includes
  - all external tests (i. e. `pytest` ran with `--external`)
  - all tests requiring a GPU
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
