### PR TITLE
Add explosion-bot workflow

### DIFF
--- a/.github/workflows/explosionbot.yml
+++ b/.github/workflows/explosionbot.yml
@@ -1,0 +1,28 @@
+name: Explosion Bot
+
+on:
+  issue_comment:
+    types:
+      - created
+      - edited
+
+jobs:
+  explosion-bot:
+    if: github.repository_owner == 'explosion'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dump GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: echo "$GITHUB_CONTEXT"
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+      - name: Install and run explosion-bot
+        run: |
+          pip install git+https://${{ secrets.EXPLOSIONBOT_TOKEN }}@github.com/explosion/explosion-bot
+          python -m explosionbot
+        env:
+          INPUT_TOKEN: ${{ secrets.EXPLOSIONBOT_TOKEN }}
+          INPUT_BK_TOKEN: ${{ secrets.BUILDKITE_SECRET }}
+          ENABLED_COMMANDS: "test_gpu,test_slow,test_slow_gpu"
+          ALLOWED_TEAMS: "spaCy"

--- a/.github/workflows/explosionbot.yml
+++ b/.github/workflows/explosionbot.yml
@@ -24,5 +24,5 @@ jobs:
         env:
           INPUT_TOKEN: ${{ secrets.EXPLOSIONBOT_TOKEN }}
           INPUT_BK_TOKEN: ${{ secrets.BUILDKITE_SECRET }}
-          ENABLED_COMMANDS: "test_llm_gpu,test_llm_external"
+          ENABLED_COMMANDS: "test_gpu,test_llm_external"
           ALLOWED_TEAMS: "spaCy"

--- a/.github/workflows/explosionbot.yml
+++ b/.github/workflows/explosionbot.yml
@@ -24,5 +24,5 @@ jobs:
         env:
           INPUT_TOKEN: ${{ secrets.EXPLOSIONBOT_TOKEN }}
           INPUT_BK_TOKEN: ${{ secrets.BUILDKITE_SECRET }}
-          ENABLED_COMMANDS: "test_gpu,test_slow,test_slow_gpu"
+          ENABLED_COMMANDS: "test_gpu,test_external"
           ALLOWED_TEAMS: "spaCy"

--- a/.github/workflows/explosionbot.yml
+++ b/.github/workflows/explosionbot.yml
@@ -24,5 +24,5 @@ jobs:
         env:
           INPUT_TOKEN: ${{ secrets.EXPLOSIONBOT_TOKEN }}
           INPUT_BK_TOKEN: ${{ secrets.BUILDKITE_SECRET }}
-          ENABLED_COMMANDS: "test_gpu,test_external"
+          ENABLED_COMMANDS: "test_llm_gpu,test_llm_external"
           ALLOWED_TEAMS: "spaCy"


### PR DESCRIPTION
This PR adds the explosion-bot workflow for spacy-llm so that we can run some CI via an issue comment. One ideal use for this is to have explosion-bot run a BuildKite pipeline for external tests, something like:

```
@explosion-bot please test_external
```

In order to run external tests (i.e., tests that interact with a third-party API) in Pull Requests (so that we can double-check if external tests pass in any machine).

TODOs:
- [x] Create buildkite pipeline for test_external (it must follow the external tests set-up, i.e., `pytest spacy_llm/tests --external`)
- [x] Add `EXPLOSIONBOT_TOKEN` and `BUILDKITE_SECRET` to spacy-llm's Github actions



### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

Chore, CI

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [ ] I ran all tests in `tests` and `usage_examples/tests`, and all new and existing tests passed. This includes
  - all external tests (i. e. `pytest` ran with `--external`)
  - all tests requiring a GPU
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
