### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1000,7 +1000,7 @@ Example config block:
 
 ```ini
 [components.llm.cache]
-@llm_misc = "spacy.BatchCache.v1",
+@llm_misc = "spacy.BatchCache.v1"
 path = "path/to/cache"
 batch_size = 64
 max_batches_in_mem = 4


### PR DESCRIPTION
With the comma in place there ... the command causes this error to appear: 

```
catalogue.RegistryError: [E893] Could not find function '"spacy.BatchCache.v1",' 
in function registry 'llm_misc'. If you're using a custom function, make sure the 
code is available. If the function is provided by a third-party package, e.g. 
spacy-transformers, make sure the package is installed in your environment.
```
