### PR TITLE
fix model name in documentation

### DIFF
--- a/migration_guide.md
+++ b/migration_guide.md
@@ -34,11 +34,11 @@ In `0.4.x`:
 ```ini
 [components.llm.model]
 @llm_models = "spacy.GPT-3-5.v1"
-name = "gpt-3-5-turbo"
+name = "gpt-3.5-turbo"
 config = {"temperature": 0.3}
 ```
 Note that the factory function (marked with `@`) refers to the name of the model. Variants of the same model can be 
-specified with the `name` attribute - for `gpt-3.5` this could be `"gpt-3-5-turbo"` or `"gpt-3-5-turbo-16k"`.
+specified with the `name` attribute - for `gpt-3.5` this could be `"gpt-3.5-turbo"` or `"gpt-3.5-turbo-16k"`.
 
 ### Models using HuggingFace
 
@@ -78,7 +78,7 @@ In `0.4.x`:
 ```ini
 [components.llm.model]
 @llm_models = "langchain.OpenAI.v1"
-name = "gpt-3-5-turbo"
+name = "gpt-3.5-turbo"
 config = {"temperature": 0.3}
 ```
 


### PR DESCRIPTION

## Description
We've got our model names wrong in the documentation, it should be `"gpt-3.5-turbo"` instead of `"gpt-3-5-turbo"`. We only replace with hyphens in the registered name for `@llm_models` 😭 

In follow-up work, we should consider matching the names of the model in a case-invariant, punctuation-ignoring fashion. But that'd require a bugfix release, so I suggest we update the documentation now first, because the current example code results in 

```
Config validation error
llm.model -> name	unexpected value; permitted: 'gpt-3.5-turbo', 'gpt-3.5-turbo-16k', 'gpt-3.5-turbo-0613', 'gpt-3.5-turbo-0613-16k'
{'@llm_models': 'spacy.GPT-3-5.v1', 'name': 'gpt-3-5-turbo', 'config': {'temperature': 0.30000000000000004}, 'strict': True}
```

### Types of change
docs bug fix

## Checklist
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran all tests in `tests` and `usage_examples/tests`, and all new and existing tests passed. This includes
  - all external tests (i. e. `pytest` ran with `--external`)
  - all tests requiring a GPU (i. e. `pytest` ran with `--gpu`)
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
