### PR TITLE
Catch blocking errors from Cohere

### DIFF
--- a/spacy_llm/models/rest/cohere/model.py
+++ b/spacy_llm/models/rest/cohere/model.py
@@ -52,9 +52,24 @@ class Cohere(REST):
             except HTTPError as ex:
                 res_content = srsly.json_loads(r.content.decode("utf-8"))
                 # Include specific error message in exception.
-                raise ValueError(
-                    f"Request to Cohere API failed: {res_content.get('message', {})}"
-                ) from ex
+                error_message = res_content.get("message", {})
+                # Catch 'blocked output' and 'blocked input' errors from Cohere
+                # This usually happens when it detects violations in their Usage guidelines.
+                # Unfortunately Cohere returns this as an HTTPError, so it cannot be caught in the response.
+                if "blocked" in error_message:
+                    # Only raise an error when strict. If strict is False, do
+                    # nothing and parse the response as usual.
+                    if self._strict:
+                        raise ValueError(
+                            f"Cohere API returned a blocking error. {error_message}. "
+                            "If you wish to ignore and continue, you can pass 'False' to the 'strict' argument of this model. "
+                            "However, note that this will affect how spacy-llm parses the response."
+                        ) from ex
+                else:
+                    # Catching other types of HTTPErrors (e.g., "429: too many requests")
+                    raise ValueError(
+                        f"Request to Cohere API failed: {error_message}"
+                    ) from ex
             response = r.json()
 
             # Cohere returns a 'message' key when there is an error
@@ -73,16 +88,18 @@ class Cohere(REST):
         # timeout is larger.
         responses = [_request({"prompt": prompt}) for prompt in prompts]
         for response in responses:
-            for result in response["generations"]:
-                if "text" in result:
-                    # Although you can set the number of completions in Cohere
-                    # to be greater than 1, we only need to return a single value.
-                    # In this case, we will just return the very first output.
-                    api_responses.append(result["text"])
-                    break
-                else:
-                    api_responses.append(srsly.json_dumps(response))
-
+            if "generations" in response:
+                for result in response["generations"]:
+                    if "text" in result:
+                        # Although you can set the number of completions in Cohere
+                        # to be greater than 1, we only need to return a single value.
+                        # In this case, we will just return the very first output.
+                        api_responses.append(result["text"])
+                        break
+                    else:
+                        api_responses.append(srsly.json_dumps(response))
+            else:
+                api_responses.append(srsly.json_dumps(response))
         return api_responses
 
     @classmethod


### PR DESCRIPTION
Sometimes, Cohere returns a blocking error (e.g., blocked output or blocked input) because of some violation to their [Usage Agreement](https://docs.cohere.com/docs/usage-guidelines).  We want to catch those and give users the option to "ignore" it via the `self._strict` argument. The error is often returned as an `HTTPError`, so there's no way to catch it from the response.

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

Bug fix

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [ ] I ran all tests in `tests` and `usage_examples/tests`, and all new and existing tests passed. This includes
  - all external tests (i. e. `pytest` ran with `--external`)
  - all tests requiring a GPU (i. e. `pytest` ran with `--gpu`)
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
