### PR TITLE
Fix Claude-2 completions endpoint

### DIFF
--- a/spacy_llm/models/rest/anthropic/model.py
+++ b/spacy_llm/models/rest/anthropic/model.py
@@ -25,11 +25,6 @@ class SystemPrompt(str, Enum):
 
 
 class Anthropic(REST):
-    MODEL_NAMES = {
-        "claude-1": Literal["claude-1", "claude-1-100k"],
-        "claude-2": Literal["claude-2", "claude-2-100k"],
-    }
-
     @property
     def credentials(self) -> Dict[str, str]:
         # Fetch and check the key, set up headers

--- a/spacy_llm/models/rest/anthropic/model.py
+++ b/spacy_llm/models/rest/anthropic/model.py
@@ -7,7 +7,6 @@ import requests  # type: ignore[import]
 import srsly  # type: ignore[import]
 from requests import HTTPError
 
-from ....compat import Literal
 from ..base import REST
 
 

--- a/spacy_llm/models/rest/anthropic/registry.py
+++ b/spacy_llm/models/rest/anthropic/registry.py
@@ -32,7 +32,7 @@ def anthropic_claude_2(
     """
     return Anthropic(
         name=name,
-        endpoint=Endpoints.COMPLETIONS,
+        endpoint=Endpoints.COMPLETIONS.value,
         config=config,
         strict=strict,
         max_tries=max_tries,


### PR DESCRIPTION
Turns out, I wasn't able to sync my changes with develop (sorry, it was my bad), hence the new Claude 2 API wasn't included in the earlier fix (cf. https://github.com/explosion/spacy-llm/commit/c52d06215e9ad23079cfcadf46fd35653a9e8acb). **This PR merges to "develop" this time.**


### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

Bug fix

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [X] I confirm that I have the right to submit this contribution under the project's MIT license.
- [X] I ran all tests in `tests` and `usage_examples/tests`, and all new and existing tests passed. This includes
  - all external tests (i. e. `pytest` ran with `--external`)
  - all tests requiring a GPU (i. e. `pytest` ran with `--gpu`)
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
