### PR TITLE
remove redundant _examples field

### DIFF
--- a/spacy_llm/tasks/sentiment.py
+++ b/spacy_llm/tasks/sentiment.py
@@ -58,7 +58,6 @@ class SentimentTask(SerializableTask[SentimentExample]):
         field (str): The name of the doc extension in which to store the summary.
         """
         self._template = template
-        self._examples = examples
         self._prompt_examples = examples or []
         self._field = field
         self._check_doc_extension()
@@ -100,7 +99,7 @@ class SentimentTask(SerializableTask[SentimentExample]):
         for doc in docs:
             prompt = _template.render(
                 text=doc.text,
-                examples=self._examples,
+                examples=self._prompt_examples,
             )
             yield prompt
 

--- a/spacy_llm/tasks/summarization.py
+++ b/spacy_llm/tasks/summarization.py
@@ -65,7 +65,6 @@ class SummarizationTask(SerializableTask[SummarizationExample]):
         field (str): The name of the doc extension in which to store the summary.
         """
         self._template = template
-        self._examples = examples
         self._max_n_words = max_n_words
         self._field = field
         self._prompt_examples = examples or []
@@ -126,7 +125,7 @@ class SummarizationTask(SerializableTask[SummarizationExample]):
         _template = environment.from_string(self._template)
         for doc in docs:
             prompt = _template.render(
-                text=doc.text, examples=self._examples, max_n_words=self._max_n_words
+                text=doc.text, examples=self._prompt_examples, max_n_words=self._max_n_words
             )
             yield prompt
 

--- a/spacy_llm/tasks/summarization.py
+++ b/spacy_llm/tasks/summarization.py
@@ -125,7 +125,9 @@ class SummarizationTask(SerializableTask[SummarizationExample]):
         _template = environment.from_string(self._template)
         for doc in docs:
             prompt = _template.render(
-                text=doc.text, examples=self._prompt_examples, max_n_words=self._max_n_words
+                text=doc.text,
+                examples=self._prompt_examples,
+                max_n_words=self._max_n_words,
             )
             yield prompt
 


### PR DESCRIPTION

## Description
Internally, few-shot examples are stored in `self._prompt_examples`, not in `self._examples` (and there's certainly no reason to store the same data twice ;-))

### Corresponding documentation PR
Not required - internally facing code only.

### Types of change
small fix

## Checklist
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran all tests in `tests` and `usage_examples/tests`, and all new and existing tests passed. This includes
  - all external tests (i. e. `pytest` ran with `--external`)
  - all tests requiring a GPU (i. e. `pytest` ran with `--gpu`)
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
