### PR TITLE
Unit test for comma in entity

### DIFF
--- a/spacy_llm/tests/tasks/test_ner.py
+++ b/spacy_llm/tests/tasks/test_ner.py
@@ -949,3 +949,20 @@ def test_regression_span_task_response_parse(
     doc = docs[0]
     pred_ents = [(ent.text, ent.label_) for ent in doc.ents]
     assert pred_ents == gold_ents
+
+
+@pytest.mark.external
+@pytest.mark.skipif(has_openai_key is False, reason="OpenAI API key not available")
+def test_entity_with_comma(fewshot_cfg_string_v3_lds):
+    config = Config().from_str(fewshot_cfg_string_v3_lds)
+    nlp = spacy.util.load_model_from_config(config, auto_fill=True)
+    text = "Somebody with the name 'Louis, the XVIIth', and Bob both live in Ireland."
+    doc = nlp(text)
+    ents = doc.ents
+    assert len(ents) == 3
+    assert ents[0].text == "'Louis, the XVIIth'" or "Louis, the XVIIth"
+    assert ents[0].label_ == "PER"
+    assert ents[1].text == "Bob"
+    assert ents[1].label_ == "PER"
+    assert ents[2].text == "Ireland"
+    assert ents[2].label_ == "LOC"


### PR DESCRIPTION


## Description
Add unit test that checks that the new NER.v3 task can deal with comma's in entities. Taken from https://github.com/explosion/spacy-llm/pull/195.

### Corresponding documentation PR
NA

### Types of change
Unit test

## Checklist
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran all tests in `tests` and `usage_examples/tests`, and all new and existing tests passed. This includes
  - all external tests (i. e. `pytest` ran with `--external`)
  - all tests requiring a GPU (i. e. `pytest` ran with `--gpu`)
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
