### PR TITLE
Fixes for Pydantic v2 compat

### DIFF
--- a/spacy_llm/compat.py
+++ b/spacy_llm/compat.py
@@ -48,3 +48,13 @@ try:
 except ImportError:
     accelerate = None
     has_accelerate = False
+
+
+from pydantic import VERSION
+
+PYDANTIC_V2 = VERSION.startswith("2.")
+
+if PYDANTIC_V2:
+    from pydantic.v1 import BaseModel, ValidationError, validator  # noqa: F401
+else:
+    from pydantic import BaseModel, ValidationError, validator  # noqa: F401

--- a/spacy_llm/tasks/rel/parser.py
+++ b/spacy_llm/tasks/rel/parser.py
@@ -3,11 +3,7 @@ from typing import Iterable, List
 from spacy.tokens import Doc
 from wasabi import msg
 
-try:
-    from pydantic.v1 import ValidationError
-except ImportError:
-    from pydantic import ValidationError
-
+from ...compat import ValidationError
 from .task import RELTask
 from .util import RelationItem
 

--- a/spacy_llm/tasks/rel/util.py
+++ b/spacy_llm/tasks/rel/util.py
@@ -1,13 +1,8 @@
 from typing import List
 
-try:
-    from pydantic.v1 import BaseModel, validator
-except ImportError:
-    from pydantic import BaseModel, validator
-
 from spacy.training import Example
 
-from ...compat import Self
+from ...compat import BaseModel, Self, validator
 from ...ty import FewshotExample
 
 
@@ -47,8 +42,7 @@ class RELExample(FewshotExample):
             )
             for ent in example.reference.ents
         ]
-
-        return cls.construct(
+        return cls(
             text=example.reference.text,
             ents=entities,
             relations=example.reference._.rel,

--- a/spacy_llm/tasks/span/examples.py
+++ b/spacy_llm/tasks/span/examples.py
@@ -1,9 +1,9 @@
 import abc
 from typing import Dict, Iterable, List
 
-from pydantic import BaseModel
 from spacy.tokens import Span
 
+from ...compat import BaseModel
 from ...ty import FewshotExample, Self
 
 

--- a/spacy_llm/tasks/summarization/util.py
+++ b/spacy_llm/tasks/summarization/util.py
@@ -1,7 +1,6 @@
-from pydantic import BaseModel
 from spacy.training import Example
 
-from ...compat import Self
+from ...compat import BaseModel, Self
 
 
 class SummarizationExample(BaseModel):

--- a/spacy_llm/tasks/textcat/util.py
+++ b/spacy_llm/tasks/textcat/util.py
@@ -1,10 +1,9 @@
 from typing import Any, Dict, Iterable
 
-from pydantic import BaseModel
 from spacy.scorer import Scorer
 from spacy.training import Example
 
-from ...compat import Self
+from ...compat import BaseModel, Self
 
 
 class TextCatExample(BaseModel):

--- a/spacy_llm/tests/tasks/test_ner.py
+++ b/spacy_llm/tests/tasks/test_ner.py
@@ -7,13 +7,12 @@ import pytest
 import spacy
 import srsly
 from confection import Config
-from pydantic import ValidationError
 from spacy.language import Language
 from spacy.tokens import Span
 from spacy.training import Example
 from spacy.util import make_tempdir
 
-from spacy_llm.compat import Literal
+from spacy_llm.compat import Literal, ValidationError
 from spacy_llm.pipeline import LLMWrapper
 from spacy_llm.registry import fewshot_reader, file_reader, lowercase_normalizer
 from spacy_llm.registry import strip_normalizer

--- a/spacy_llm/ty.py
+++ b/spacy_llm/ty.py
@@ -6,12 +6,11 @@ from pathlib import Path
 from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Type, TypeVar
 from typing import Union, cast
 
-from pydantic import BaseModel
 from spacy.tokens import Doc
 from spacy.training.example import Example
 from spacy.vocab import Vocab
 
-from .compat import Protocol, Self, runtime_checkable
+from .compat import BaseModel, Protocol, Self, runtime_checkable
 from .models import langchain
 
 _PromptType = Any


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

We have a mixture of imports for the pydantic `BaseModel` from both v2 and v1. 
This PR standardizes imports around `v1` by adding `BaseModel`, `ValidationError` and `validator` to the compat module. Fixes the need for `cls.construct` for the relations module.

### Corresponding documentation PR
<!--- Add the link to the corresponding documentation PR here, if applicable. -->

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

Enhancment

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran all tests in `tests` and `usage_examples/tests`, and all new and existing tests passed. This includes
  - all external tests (i. e. `pytest` ran with `--external`)
  - all tests requiring a GPU (i. e. `pytest` ran with `--gpu`)
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
