### PR TITLE
Consistently use same default model

### DIFF
--- a/spacy_llm/models/rest/anthropic/model.py
+++ b/spacy_llm/models/rest/anthropic/model.py
@@ -32,7 +32,7 @@ class Anthropic(REST):
             warnings.warn(
                 "Could not find the API key to access the Anthropic Claude API. Ensure you have an API key "
                 "set up via the Anthropic console (https://console.anthropic.com/), then make it available as "
-                "an environment variable 'ANTHROPIC_API_KEY."
+                "an environment variable 'ANTHROPIC_API_KEY'."
             )
 
         return {"X-API-Key": api_key if api_key else ""}

--- a/spacy_llm/models/rest/openai/model.py
+++ b/spacy_llm/models/rest/openai/model.py
@@ -25,7 +25,7 @@ class OpenAI(REST):
             warnings.warn(
                 "Could not find the API key to access the OpenAI API. Ensure you have an API key "
                 "set up via https://platform.openai.com/account/api-keys, then make it available as "
-                "an environment variable 'OPENAI_API_KEY."
+                "an environment variable 'OPENAI_API_KEY'."
             )
 
         # Check the access and get a list of available models to verify the model argument (if not None)

--- a/spacy_llm/pipeline/llm.py
+++ b/spacy_llm/pipeline/llm.py
@@ -80,7 +80,7 @@ def make_llm(
     if task is None:
         raise ValueError(
             "Argument `task` has not been specified, but is required (e. g. {'@llm_tasks': "
-            "'spacy.NER.v2'})."
+            "'spacy.NER.v3'})."
         )
     if validate_types:
         validate_type_consistency(task, model)

--- a/spacy_llm/pipeline/llm.py
+++ b/spacy_llm/pipeline/llm.py
@@ -21,6 +21,22 @@ from ..ty import Serializable, validate_type_consistency
 logger = logging.getLogger("spacy_llm")
 logger.addHandler(logging.NullHandler())
 
+DEFAULT_MODEL_CONFIG = {
+    "@llm_models": "spacy.GPT-3-5.v2",
+    "strict": True,
+}
+DEFAULT_CACHE_CONFIG = (
+    {
+        "@llm_misc": "spacy.BatchCache.v1",
+        "path": None,
+        "batch_size": 64,
+        "max_batches_in_mem": 4,
+    },
+)
+
+DEFAULT_SAVE_IO = False
+DEFAULT_VALIDATE_TYPES = True
+
 
 class CacheConfigType(TypedDict):
     path: Optional[Path]
@@ -34,18 +50,10 @@ class CacheConfigType(TypedDict):
     assigns=[],
     default_config={
         "task": None,
-        "model": {
-            "@llm_models": "spacy.GPT-3-5.v1",
-            "strict": True,
-        },
-        "cache": {
-            "@llm_misc": "spacy.BatchCache.v1",
-            "path": None,
-            "batch_size": 64,
-            "max_batches_in_mem": 4,
-        },
-        "save_io": False,
-        "validate_types": True,
+        "model": DEFAULT_MODEL_CONFIG,
+        "cache": DEFAULT_CACHE_CONFIG,
+        "save_io": DEFAULT_SAVE_IO,
+        "validate_types": DEFAULT_VALIDATE_TYPES,
     },
 )
 def make_llm(

--- a/spacy_llm/pipeline/llm.py
+++ b/spacy_llm/pipeline/llm.py
@@ -22,7 +22,7 @@ logger = logging.getLogger("spacy_llm")
 logger.addHandler(logging.NullHandler())
 
 DEFAULT_MODEL_CONFIG = {
-    "@llm_models": "spacy.GPT-3-5.v1",
+    "@llm_models": "spacy.GPT-3-5.v2",
     "strict": True,
 }
 DEFAULT_CACHE_CONFIG = {

--- a/spacy_llm/pipeline/llm.py
+++ b/spacy_llm/pipeline/llm.py
@@ -22,17 +22,15 @@ logger = logging.getLogger("spacy_llm")
 logger.addHandler(logging.NullHandler())
 
 DEFAULT_MODEL_CONFIG = {
-    "@llm_models": "spacy.GPT-3-5.v2",
+    "@llm_models": "spacy.GPT-3-5.v1",
     "strict": True,
 }
-DEFAULT_CACHE_CONFIG = (
-    {
-        "@llm_misc": "spacy.BatchCache.v1",
-        "path": None,
-        "batch_size": 64,
-        "max_batches_in_mem": 4,
-    },
-)
+DEFAULT_CACHE_CONFIG = {
+    "@llm_misc": "spacy.BatchCache.v1",
+    "path": None,
+    "batch_size": 64,
+    "max_batches_in_mem": 4,
+}
 
 DEFAULT_SAVE_IO = False
 DEFAULT_VALIDATE_TYPES = True

--- a/spacy_llm/tasks/__init__.py
+++ b/spacy_llm/tasks/__init__.py
@@ -1,6 +1,7 @@
 from spacy import Language
 
-from ..pipeline.llm import make_llm
+from ..pipeline.llm import DEFAULT_CACHE_CONFIG, DEFAULT_MODEL_CONFIG, DEFAULT_SAVE_IO
+from ..pipeline.llm import DEFAULT_VALIDATE_TYPES, make_llm
 from .builtin_task import BuiltinTask
 from .lemma import LemmaTask, make_lemma_task
 from .ner import NERTask, make_ner_task_v3
@@ -20,21 +21,16 @@ _LATEST_TASKS = (
     "spacy.TextCat.v3",
 )
 
-# Register llm_TASK factories with NoOp models.
+# Register llm_TASK factories with default models.
 for task_handle in _LATEST_TASKS:
     Language.factory(
         name=f"llm_{task_handle.split('.')[1].lower()}",
         default_config={
             "task": {"@llm_tasks": task_handle},
-            "model": {"@llm_models": "spacy.NoOp.v1"},
-            "cache": {
-                "@llm_misc": "spacy.BatchCache.v1",
-                "path": None,
-                "batch_size": 64,
-                "max_batches_in_mem": 4,
-            },
-            "save_io": False,
-            "validate_types": True,
+            "model": DEFAULT_MODEL_CONFIG,
+            "cache": DEFAULT_CACHE_CONFIG,
+            "save_io": DEFAULT_SAVE_IO,
+            "validate_types": DEFAULT_VALIDATE_TYPES,
         },
         func=make_llm,
     )

--- a/spacy_llm/tests/pipeline/test_llm.py
+++ b/spacy_llm/tests/pipeline/test_llm.py
@@ -304,7 +304,7 @@ def test_llm_task_factories():
 
         [components.llm]
         factory = "llm_{task_handle.split('.')[1].lower()}"
-        
+
         [components.llm.model]
         @llm_models = "test.NoOpModel.v1"
         """

--- a/spacy_llm/tests/pipeline/test_llm.py
+++ b/spacy_llm/tests/pipeline/test_llm.py
@@ -304,6 +304,9 @@ def test_llm_task_factories():
 
         [components.llm]
         factory = "llm_{task_handle.split('.')[1].lower()}"
+        
+        [components.llm.model]
+        @llm_models = "test.NoOpModel.v1"
         """
         config = Config().from_str(cfg_string)
         assemble_from_config(config)

--- a/spacy_llm/tests/tasks/test_ner.py
+++ b/spacy_llm/tests/tasks/test_ner.py
@@ -250,6 +250,35 @@ def test_ner_predict(cfg_str, text, gold_ents, request):
 
 @pytest.mark.external
 @pytest.mark.skipif(has_openai_key is False, reason="OpenAI API key not available")
+@pytest.mark.parametrize(
+    "text,gold_ents",
+    [
+        (
+            "Marc and Bob both live in Ireland.",
+            [("Marc", "PER"), ("Bob", "PER"), ("Ireland", "LOC")],
+        ),
+    ],
+)
+def test_llm_ner_predict(text, gold_ents):
+    """Use llm_ner factory with default OpenAI model to get NER results.
+    Note that this test may fail randomly, as the LLM's output is unguaranteed to be consistent/predictable
+    """
+    nlp = spacy.blank("en")
+    llm = nlp.add_pipe("llm_ner")
+    for ent_str, ent_label in gold_ents:
+        llm.add_label(ent_label)
+    doc = nlp(text)
+
+    assert len(doc.ents) == len(gold_ents)
+    for pred_ent, gold_ent in zip(doc.ents, gold_ents):
+        assert (
+            gold_ent[0] in pred_ent.text
+        )  # occassionally, the LLM predicts "in Ireland" instead of just "Ireland"
+        assert pred_ent.label_ in gold_ent[1].split("|")
+
+
+@pytest.mark.external
+@pytest.mark.skipif(has_openai_key is False, reason="OpenAI API key not available")
 def test_ner_io(nlp: Language):
     assert nlp.pipe_names == ["llm"]
     # ensure you can save a pipeline to disk and run it after loading

--- a/spacy_llm/tests/test_combinations.py
+++ b/spacy_llm/tests/test_combinations.py
@@ -17,8 +17,8 @@ from spacy_llm.pipeline import LLMWrapper
 )
 @pytest.mark.parametrize(
     "task",
-    ["spacy.NER.v1", "spacy.NER.v2", "spacy.TextCat.v1"],
-    ids=["ner.v1", "ner.v2", "textcat"],
+    ["spacy.NER.v1", "spacy.NER.v3", "spacy.TextCat.v1"],
+    ids=["ner.v1", "ner.v3", "textcat"],
 )
 @pytest.mark.parametrize("n_process", [1])  # , 2
 def test_combinations(model: str, task: str, n_process: int):


### PR DESCRIPTION
## Description
Use the same default model for the `llm` factory and the `llm_task` factories, so that these are entirely equivalent:
```
llm = nlp.add_pipe("llm", config={"task": {"@llm_tasks": "spacy.NER.v3"}})
```
and
```
llm = nlp.add_pipe("llm_ner")
```

### Corresponding documentation PR
<!--- Add the link to the corresponding documentation PR here, if applicable. -->
NA

### Types of change
fix

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran all tests in `tests` and `usage_examples/tests`, and all new and existing tests passed. This includes
  - all external tests (i. e. `pytest` ran with `--external`)
  - all tests requiring a GPU (i. e. `pytest` ran with `--gpu`)
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
