### PR TITLE
Support arbitrarily long docs

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-version = 0.6.1
+version = 0.6.2
 description = Integrating LLMs into structured NLP pipelines
 author = Explosion
 author_email = contact@explosion.ai

--- a/spacy_llm/models/hf/base.py
+++ b/spacy_llm/models/hf/base.py
@@ -61,6 +61,13 @@ class HuggingFace(abc.ABC):
 
     @property
     @abc.abstractmethod
+    def context_length(self) -> int:
+        """Returns context length in number of tokens for this model.
+        RETURNS (int): Max. number of tokens in allowed in prompt for the current model.
+        """
+
+    @property
+    @abc.abstractmethod
     def hf_account(self) -> str:
         """Name of HF account for this model.
         RETURNS (str): Name of HF account.

--- a/spacy_llm/models/hf/dolly.py
+++ b/spacy_llm/models/hf/dolly.py
@@ -46,6 +46,10 @@ class Dolly(HuggingFace):
             default_cfg_run,
         )
 
+    @property
+    def context_length(self) -> int:
+        return 2048
+
 
 @registry.llm_models("spacy.Dolly.v1")
 def dolly_hf(

--- a/spacy_llm/models/hf/falcon.py
+++ b/spacy_llm/models/hf/falcon.py
@@ -63,6 +63,10 @@ class Falcon(HuggingFace):
             default_cfg_run,
         )
 
+    @property
+    def context_length(self) -> int:
+        return 2048
+
 
 @registry.llm_models("spacy.Falcon.v1")
 def falcon_hf(

--- a/spacy_llm/models/hf/llama2.py
+++ b/spacy_llm/models/hf/llama2.py
@@ -49,6 +49,10 @@ class Llama2(HuggingFace):
     def compile_default_configs() -> Tuple[Dict[str, Any], Dict[str, Any]]:
         return HuggingFace.compile_default_configs()
 
+    @property
+    def context_length(self) -> int:
+        return 4096
+
 
 @registry.llm_models("spacy.Llama2.v1")
 def llama2_hf(

--- a/spacy_llm/models/hf/mistral.py
+++ b/spacy_llm/models/hf/mistral.py
@@ -82,6 +82,10 @@ class Mistral(HuggingFace):
             default_cfg_run,
         )
 
+    @property
+    def context_length(self) -> int:
+        return 8000
+
 
 @registry.llm_models("spacy.Mistral.v1")
 def mistral_hf(

--- a/spacy_llm/models/hf/openllama.py
+++ b/spacy_llm/models/hf/openllama.py
@@ -76,6 +76,10 @@ class OpenLLaMA(HuggingFace):
             {**default_cfg_run, "max_new_tokens": 32},
         )
 
+    @property
+    def context_length(self) -> int:
+        return 2048
+
 
 @registry.llm_models("spacy.OpenLLaMA.v1")
 def openllama_hf(

--- a/spacy_llm/models/hf/stablelm.py
+++ b/spacy_llm/models/hf/stablelm.py
@@ -107,6 +107,10 @@ class StableLM(HuggingFace):
             },
         )
 
+    @property
+    def context_length(self) -> int:
+        return 4096
+
 
 @registry.llm_models("spacy.StableLM.v1")
 def stablelm_hf(

--- a/spacy_llm/models/rest/anthropic/model.py
+++ b/spacy_llm/models/rest/anthropic/model.py
@@ -54,7 +54,7 @@ class Anthropic(REST):
         headers = {
             **self._credentials,
             "model": self._name,
-            "anthropic_version": self._config.get("anthropic_version", "2023-06-01"),
+            "anthropic-version": self._config.get("anthropic-version", "2023-06-01"),
             "Content-Type": "application/json",
         }
 

--- a/spacy_llm/models/rest/anthropic/model.py
+++ b/spacy_llm/models/rest/anthropic/model.py
@@ -1,7 +1,7 @@
 import os
 import warnings
 from enum import Enum
-from typing import Any, Dict, Iterable, List, Sized, Tuple
+from typing import Any, Dict, Iterable, List, Sized
 
 import requests  # type: ignore[import]
 import srsly  # type: ignore[import]
@@ -108,25 +108,25 @@ class Anthropic(REST):
         assert len(api_responses) == len(prompts)
         return api_responses
 
-    @classmethod
-    def get_model_names(cls) -> Tuple[str, ...]:
-        return (
+    @staticmethod
+    def _get_context_lengths() -> Dict[str, int]:
+        return {
             # claude-2
-            "claude-2",
-            "claude-2-100k",
+            "claude-2": 100000,
+            "claude-2-100k": 100000,
             # claude-1
-            "claude-1",
-            "claude-1-100k",
+            "claude-1": 100000,
+            "claude-1-100k": 100000,
             # claude-instant-1
-            "claude-instant-1",
-            "claude-instant-1-100k",
+            "claude-instant-1": 100000,
+            "claude-instant-1-100k": 100000,
             # claude-instant-1.1
-            "claude-instant-1.1",
-            "claude-instant-1.1-100k",
+            "claude-instant-1.1": 100000,
+            "claude-instant-1.1-100k": 100000,
             # claude-1.3
-            "claude-1.3",
-            "claude-1.3-100k",
+            "claude-1.3": 100000,
+            "claude-1.3-100k": 100000,
             # others
-            "claude-1.0",
-            "claude-1.2",
-        )
+            "claude-1.0": 100000,
+            "claude-1.2": 100000,
+        }

--- a/spacy_llm/models/rest/azure/registry.py
+++ b/spacy_llm/models/rest/azure/registry.py
@@ -10,6 +10,7 @@ _DEFAULT_TEMPERATURE = 0.0
 
 @registry.llm_models("spacy.Azure.v1")
 def azure_openai(
+    deployment_name: str,
     name: str,
     base_url: str,
     model_type: ModelType,
@@ -22,9 +23,14 @@ def azure_openai(
 ) -> Callable[[Iterable[str]], Iterable[str]]:
     """Returns OpenAI instance for 'gpt-4' model using REST to prompt API.
 
+    Docs on OpenAI models supported by Azure:
+    https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models#model-summary-table-and-region-availability.
+
     config (Dict[Any, Any]): LLM config passed on to the model's initialization.
-    name (str): Name of the deployment to use. Note that this does not necessarily equal the name of the model used by
-        that deployment, as deployment names in Azure OpenAI can be arbitrary.
+    deployment_name (str): Name of the deployment to use. Note that this does not necessarily equal the name of the
+        model used by that deployment, as deployment names in Azure OpenAI can be arbitrary.
+    name (str): Name of the model used by this deployment. This is required to infer the context length that can be
+        assumed for prompting.
     endpoint (str): The URL for your Azure OpenAI endpoint. This is usually something like
         "https://{prefix}.openai.azure.com/".
     model_type (ModelType): Whether the deployed model is a text completetion model (e. g.
@@ -43,6 +49,7 @@ def azure_openai(
     DOCS: https://spacy.io/api/large-language-models#models
     """
     return AzureOpenAI(
+        deployment_name=deployment_name,
         name=name,
         endpoint=base_url,
         config=config,

--- a/spacy_llm/models/rest/base.py
+++ b/spacy_llm/models/rest/base.py
@@ -79,11 +79,25 @@ class REST(abc.ABC):
         """
 
     @classmethod
-    @abc.abstractmethod
     def get_model_names(cls) -> Tuple[str, ...]:
         """Names of supported models.
         RETURNS (Tuple[str]): Names of supported models.
         """
+        return tuple(cls._get_context_lengths().keys())
+
+    @staticmethod
+    @abc.abstractmethod
+    def _get_context_lengths() -> Dict[str, int]:
+        """Get context lengths per model name.
+        RETURNS (Dict[str, int]): Dict with model name -> context length.
+        """
+
+    @property
+    def context_length(self) -> int:
+        """Returns context length in number of tokens for this model.
+        RETURNS (int): Max. number of tokens in allowed in prompt for the current model.
+        """
+        return self._get_context_lengths()[self._name]
 
     @property
     @abc.abstractmethod

--- a/spacy_llm/models/rest/cohere/model.py
+++ b/spacy_llm/models/rest/cohere/model.py
@@ -115,3 +115,12 @@ class Cohere(REST):
     @classmethod
     def get_model_names(cls) -> Tuple[str, ...]:
         return "command", "command-light", "command-light-nightly", "command-nightly"
+
+    @staticmethod
+    def _get_context_lengths() -> Dict[str, int]:
+        return {
+            "command": 4096,
+            "command-light": 4096,
+            "command-light-nightly": 4096,
+            "command-nightly": 4096,
+        }

--- a/spacy_llm/models/rest/noop/model.py
+++ b/spacy_llm/models/rest/noop/model.py
@@ -1,5 +1,6 @@
+import sys
 import time
-from typing import Dict, Iterable, Tuple
+from typing import Dict, Iterable
 
 from ..base import REST
 
@@ -34,6 +35,6 @@ class NoOpModel(REST):
         time.sleep(NoOpModel._CALL_TIMEOUT)
         return [_NOOP_RESPONSE] * len(list(prompts))
 
-    @classmethod
-    def get_model_names(cls) -> Tuple[str, ...]:
-        return ("NoOp",)
+    @staticmethod
+    def _get_context_lengths() -> Dict[str, int]:
+        return {"NoOp": sys.maxsize}

--- a/spacy_llm/models/rest/openai/model.py
+++ b/spacy_llm/models/rest/openai/model.py
@@ -1,7 +1,7 @@
 import os
 import warnings
 from enum import Enum
-from typing import Any, Dict, Iterable, List, Sized, Tuple
+from typing import Any, Dict, Iterable, List, Sized
 
 import requests  # type: ignore[import]
 import srsly  # type: ignore[import]
@@ -141,30 +141,30 @@ class OpenAI(REST):
 
         return api_responses
 
-    @classmethod
-    def get_model_names(cls) -> Tuple[str, ...]:
-        return (
+    @staticmethod
+    def _get_context_lengths() -> Dict[str, int]:
+        return {
             # gpt-4
-            "gpt-4",
-            "gpt-4-0314",
-            "gpt-4-32k",
-            "gpt-4-32k-0314",
+            "gpt-4": 8192,
+            "gpt-4-0314": 8192,
+            "gpt-4-32k": 32768,
+            "gpt-4-32k-0314": 32768,
             # gpt-3.5
-            "gpt-3.5-turbo",
-            "gpt-3.5-turbo-16k",
-            "gpt-3.5-turbo-0613",
-            "gpt-3.5-turbo-0613-16k",
-            "gpt-3.5-turbo-instruct",
+            "gpt-3.5-turbo": 4097,
+            "gpt-3.5-turbo-16k": 16385,
+            "gpt-3.5-turbo-0613": 4097,
+            "gpt-3.5-turbo-0613-16k": 16385,
+            "gpt-3.5-turbo-instruct": 4097,
             # text-davinci
-            "text-davinci-002",
-            "text-davinci-003",
+            "text-davinci-002": 4097,
+            "text-davinci-003": 4097,
             # others
-            "code-davinci-002",
-            "text-curie-001",
-            "text-babbage-001",
-            "text-ada-001",
-            "davinci",
-            "curie",
-            "babbage",
-            "ada",
-        )
+            "code-davinci-002": 8001,
+            "text-curie-001": 2049,
+            "text-babbage-001": 2049,
+            "text-ada-001": 2049,
+            "davinci": 2049,
+            "curie": 2049,
+            "babbage": 2049,
+            "ada": 2049,
+        }

--- a/spacy_llm/models/rest/palm/model.py
+++ b/spacy_llm/models/rest/palm/model.py
@@ -1,7 +1,7 @@
 import os
 import warnings
 from enum import Enum
-from typing import Any, Dict, Iterable, List, Sized, Tuple
+from typing import Any, Dict, Iterable, List, Sized
 
 import requests  # type: ignore[import]
 import srsly  # type: ignore[import]
@@ -108,6 +108,9 @@ class PaLM(REST):
 
         return api_responses
 
-    @classmethod
-    def get_model_names(cls) -> Tuple[str, ...]:
-        return "text-bison-001", "chat-bison-001"
+    @staticmethod
+    def _get_context_lengths() -> Dict[str, int]:
+        return {
+            "text-bison-001": 8192,
+            "chat-bison-001": 8192,
+        }

--- a/spacy_llm/tasks/builtin_task.py
+++ b/spacy_llm/tasks/builtin_task.py
@@ -4,7 +4,7 @@ from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Type, c
 
 import jinja2
 import srsly
-from spacy import Language, util, Errors
+from spacy import Errors, Language, util
 from spacy.tokens import Doc
 from spacy.training import Example
 
@@ -52,6 +52,7 @@ class BuiltinTask(abc.ABC):
         """
         environment = jinja2.Environment()
         _template = environment.from_string(self._template)
+
         for doc in docs:
             prompt = _template.render(
                 text=doc.text, prompt_examples=self._prompt_examples, **kwargs


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->
Support arbitrarily long docs by implementing a map-reduce approach: split docs into shards, process each shard in a separate prompt, then fuse shards together using a consensus-finding algorithm.

Steps:
```
a. Do until until entire doc has been processed:  
       a. 1. Estimate n_tokens in rendered prompt  
       a. 2. If n_tokens within bounds: use complete doc as one shard  
       a. 3. Otherwise:  
           - Identify split-off point  
           - Split off first shard  
           - Repeat from a. 3. on with rest of the (yet unsharded) doc  
   b. For each shard: execute prompt, parse response  
   c. Fuse shards into one doc instance by applying a consenus mechanism.  
       Note: the consensus mechanism can be trivial - e. g. for NER: concat all .ents into new doc - or  
       not, e. g. for classification/regression tasks - what's a doc's class if there are three shards with  
       three different textcat results?  
```

### Corresponding documentation PR
<!--- Add the link to the corresponding documentation PR here, if applicable. -->
todo

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->
New feature.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [ ] I ran all tests in `tests` and `usage_examples/tests`, and all new and existing tests passed. This includes
  - all external tests (i. e. `pytest` ran with `--external`)
  - all tests requiring a GPU (i. e. `pytest` ran with `--gpu`)
- [ ] My changes don't require a change to the documentation, or if they do, I've added all required information.
