### PR TITLE
Add label definition to add function for LabeledTask

### DIFF
--- a/spacy_llm/pipeline/llm.py
+++ b/spacy_llm/pipeline/llm.py
@@ -138,7 +138,7 @@ class LLMWrapper(Pipe):
             labels = self._task.labels
         return labels
 
-    def add_label(self, label: str, label_definition: Optional[str]) -> int:
+    def add_label(self, label: str, label_definition: Optional[str]=None) -> int:
         if not isinstance(self._task, LabeledTask):
             raise ValueError("The task of this LLM component does not have labels.")
         return self._task.add_label(label, label_definition)

--- a/spacy_llm/pipeline/llm.py
+++ b/spacy_llm/pipeline/llm.py
@@ -138,11 +138,11 @@ class LLMWrapper(Pipe):
             labels = self._task.labels
         return labels
 
-    def add_label(self, label: str, label_definition: Optional[str]=None) -> int:
+    def add_label(self, label: str, label_definition: Optional[str] = None) -> int:
         if not isinstance(self._task, LabeledTask):
             raise ValueError("The task of this LLM component does not have labels.")
         return self._task.add_label(label, label_definition)
-    
+
     def clear(self) -> None:
         if not isinstance(self._task, LabeledTask):
             raise ValueError("The task of this LLM component does not have labels.")

--- a/spacy_llm/pipeline/llm.py
+++ b/spacy_llm/pipeline/llm.py
@@ -138,10 +138,15 @@ class LLMWrapper(Pipe):
             labels = self._task.labels
         return labels
 
-    def add_label(self, label: str) -> int:
+    def add_label(self, label: str, label_definition: Optional[str]) -> int:
         if not isinstance(self._task, LabeledTask):
             raise ValueError("The task of this LLM component does not have labels.")
-        return self._task.add_label(label)
+        return self._task.add_label(label, label_definition)
+    
+    def clear(self) -> None:
+        if not isinstance(self._task, LabeledTask):
+            raise ValueError("The task of this LLM component does not have labels.")
+        return self._task.clear()
 
     @property
     def task(self) -> LLMTask:

--- a/spacy_llm/tasks/builtin_task.py
+++ b/spacy_llm/tasks/builtin_task.py
@@ -312,13 +312,24 @@ class BuiltinTaskWithLabels(BuiltinTask, abc.ABC):
     def labels(self) -> Tuple[str, ...]:
         return tuple(self._label_dict.values())
 
-    def add_label(self, label: str) -> int:
+    def add_label(self, label: str, label_definition: Optional[str]) -> int:
+        """ Add a label to the task """
         if not isinstance(label, str):
             raise ValueError(Errors.E187)
         if label in self.labels:
             return 0
         self._label_dict[self._normalizer(label)] = label
+        if label_definition is None:
+            return 1
+        if self._label_definition is None:
+            self._label_definition = {}
+        self._label_definition[label] = label_definition
         return 1
+    
+    def clear(self) -> None:
+        """Reset all labels."""
+        self._label_dict = {}
+        self._label_definition = None
 
     @property
     def normalizer(self) -> Callable[[str], str]:

--- a/spacy_llm/tasks/builtin_task.py
+++ b/spacy_llm/tasks/builtin_task.py
@@ -312,8 +312,8 @@ class BuiltinTaskWithLabels(BuiltinTask, abc.ABC):
     def labels(self) -> Tuple[str, ...]:
         return tuple(self._label_dict.values())
 
-    def add_label(self, label: str, label_definition: Optional[str]=None) -> int:
-        """ Add a label to the task """
+    def add_label(self, label: str, label_definition: Optional[str] = None) -> int:
+        """Add a label to the task"""
         if not isinstance(label, str):
             raise ValueError(Errors.E187)
         if label in self.labels:
@@ -325,7 +325,7 @@ class BuiltinTaskWithLabels(BuiltinTask, abc.ABC):
             self._label_definitions = {}
         self._label_definitions[label] = label_definition
         return 1
-    
+
     def clear(self) -> None:
         """Reset all labels."""
         self._label_dict = {}

--- a/spacy_llm/tasks/builtin_task.py
+++ b/spacy_llm/tasks/builtin_task.py
@@ -312,7 +312,7 @@ class BuiltinTaskWithLabels(BuiltinTask, abc.ABC):
     def labels(self) -> Tuple[str, ...]:
         return tuple(self._label_dict.values())
 
-    def add_label(self, label: str, label_definition: Optional[str]) -> int:
+    def add_label(self, label: str, label_definition: Optional[str]=None) -> int:
         """ Add a label to the task """
         if not isinstance(label, str):
             raise ValueError(Errors.E187)

--- a/spacy_llm/tasks/builtin_task.py
+++ b/spacy_llm/tasks/builtin_task.py
@@ -321,15 +321,15 @@ class BuiltinTaskWithLabels(BuiltinTask, abc.ABC):
         self._label_dict[self._normalizer(label)] = label
         if label_definition is None:
             return 1
-        if self._label_definition is None:
-            self._label_definition = {}
-        self._label_definition[label] = label_definition
+        if self._label_definitions is None:
+            self._label_definitions = {}
+        self._label_definitions[label] = label_definition
         return 1
     
     def clear(self) -> None:
         """Reset all labels."""
         self._label_dict = {}
-        self._label_definition = None
+        self._label_definitions = None
 
     @property
     def normalizer(self) -> Callable[[str], str]:

--- a/spacy_llm/tests/tasks/test_ner.py
+++ b/spacy_llm/tests/tasks/test_ner.py
@@ -992,7 +992,10 @@ def test_add_label():
     doc = nlp(text)
     assert len(doc.ents) == 0
 
-    for label, definition in [("PERSON", "Every person with the name Jack"), ("LOCATION", None)]:
+    for label, definition in [
+        ("PERSON", "Every person with the name Jack"),
+        ("LOCATION", None),
+    ]:
         llm.add_label(label, definition)
     doc = nlp(text)
     assert len(doc.ents) == 2

--- a/spacy_llm/tests/tasks/test_ner.py
+++ b/spacy_llm/tests/tasks/test_ner.py
@@ -992,10 +992,10 @@ def test_add_label():
     doc = nlp(text)
     assert len(doc.ents) == 0
 
-    for label, definition in [("PERSON", "A person is a human being, an individual belonging to the species Homo sapiens."), ("LOCATION", None)]:
+    for label, definition in [("PERSON", "Every person with the name Jack"), ("LOCATION", None)]:
         llm.add_label(label, definition)
     doc = nlp(text)
-    assert len(doc.ents) == 3
+    assert len(doc.ents) == 2
 
 
 @pytest.mark.external

--- a/spacy_llm/tests/tasks/test_ner.py
+++ b/spacy_llm/tests/tasks/test_ner.py
@@ -992,7 +992,38 @@ def test_add_label():
     doc = nlp(text)
     assert len(doc.ents) == 0
 
+    for label, definition in [("PERSON", "A person is a human being, an individual belonging to the species Homo sapiens."), ("LOCATION", None)]:
+        llm.add_label(label, definition)
+    doc = nlp(text)
+    assert len(doc.ents) == 3
+
+
+@pytest.mark.external
+@pytest.mark.skipif(has_openai_key is False, reason="OpenAI API key not available")
+def test_clear_label():
+    nlp = spacy.blank("en")
+    llm = nlp.add_pipe(
+        "llm",
+        config={
+            "task": {
+                "@llm_tasks": "spacy.NER.v3",
+            },
+            "model": {
+                "@llm_models": "spacy.GPT-3-5.v1",
+            },
+        },
+    )
+
+    nlp.initialize()
+    text = "Jack and Jill visited France."
+    doc = nlp(text)
+
     for label in ["PERSON", "LOCATION"]:
         llm.add_label(label)
     doc = nlp(text)
     assert len(doc.ents) == 3
+
+    llm.clear()
+
+    doc = nlp(text)
+    assert len(doc.ents) == 0

--- a/spacy_llm/ty.py
+++ b/spacy_llm/ty.py
@@ -136,7 +136,7 @@ class LabeledTask(Protocol):
     def labels(self) -> Tuple[str, ...]:
         ...
 
-    def add_label(self, label: str, label_definition: Optional[str]=None) -> int:
+    def add_label(self, label: str, label_definition: Optional[str] = None) -> int:
         ...
 
     def clear(self) -> None:

--- a/spacy_llm/ty.py
+++ b/spacy_llm/ty.py
@@ -136,7 +136,7 @@ class LabeledTask(Protocol):
     def labels(self) -> Tuple[str, ...]:
         ...
 
-    def add_label(self, label: str, label_definition: Optional[str]) -> int:
+    def add_label(self, label: str, label_definition: Optional[str]=None) -> int:
         ...
 
     def clear(self) -> None:

--- a/spacy_llm/ty.py
+++ b/spacy_llm/ty.py
@@ -136,7 +136,10 @@ class LabeledTask(Protocol):
     def labels(self) -> Tuple[str, ...]:
         ...
 
-    def add_label(self, label: str) -> int:
+    def add_label(self, label: str, label_definition: Optional[str]) -> int:
+        ...
+
+    def clear(self) -> None:
         ...
 
 


### PR DESCRIPTION
## Description
I really liked the changes in #277  and would like to provide additional functionality. With this changes it is possible to add a label_definition and clear all labels from the task. I added the clear function to make the component in line with the other components like the attribute ruler e.g.
https://github.com/explosion/spaCy/blob/d717123819fb02cf81dcc26be305c0f9cd9893bf/spacy/pipeline/attributeruler.py#L102 

### Types of change
new feature

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [X] I confirm that I have the right to submit this contribution under the project's MIT license.
- [X] I ran all tests in `tests` and `usage_examples/tests`, and all new and existing tests passed. This includes
  - all external tests (i. e. `pytest` ran with `--external`)
  - all tests requiring a GPU (i. e. `pytest` ran with `--gpu`)
- [ ] My changes don't require a change to the documentation, or if they do, I've added all required information.
