### PR TITLE
Small change in user warning

### DIFF
--- a/spacy_llm/tasks/textcat/task.py
+++ b/spacy_llm/tasks/textcat/task.py
@@ -77,8 +77,8 @@ class TextCatTask(BuiltinTaskWithLabels):
         self._scorer = scorer
 
         if self._use_binary and not self._exclusive_classes:
-            msg.warn(
-                "Binary classification should always be exclusive. Setting "
+            msg.info(
+                "Detected binary classification: setting "
                 "the `exclusive_classes` parameter to True."
             )
             self._exclusive_classes = True


### PR DESCRIPTION

## Description
Our built-in textcat versions `spacy.TextCat.v1` to `v3` set `exclusive_classes` to `False` by default. This means that a user might not realise they've specified a conflicting configuration for their data, and this warning can come as a bit of a surprise. I suggest to make this an `info` logging instead.

### Corresponding documentation PR
Not required.

### Types of change
UX update

## Checklist
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran all tests in `tests` and `usage_examples/tests`, and all new and existing tests passed. This includes
  - all external tests (i. e. `pytest` ran with `--external`)
  - all tests requiring a GPU (i. e. `pytest` ran with `--gpu`)
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
