### PR TITLE
Add more links to spaCy docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,20 +32,20 @@ This package integrates Large Language Models (LLMs) into [spaCy](https://spacy.
   - **[Mistral](https://huggingface.co/mistralai)**
 - Integration with [LangChain](https://github.com/hwchase17/langchain) 🦜️🔗 - all `langchain` models and features can be used in `spacy-llm`
 - Tasks available out of the box:
-  - Named Entity Recognition
-  - Text classification
-  - Lemmatization
-  - Relationship extraction
-  - Sentiment analysis
-  - Span categorization
-  - Summarization
-  - Entity linking
-  - Translation
-  - Raw prompt execution for maximum flexibility
+  - [Named Entity Recognition](https://spacy.io/api/large-language-models#ner)
+  - [Text classification](https://spacy.io/api/large-language-models#textcat)
+  - [Lemmatization](https://spacy.io/api/large-language-models#lemma)
+  - [Relationship extraction](https://spacy.io/api/large-language-models#rel)
+  - [Sentiment analysis](https://spacy.io/api/large-language-models#sentiment)
+  - [Span categorization](https://spacy.io/api/large-language-models#spancat)
+  - [Summarization] (https://spacy.io/api/large-language-models#summarization)
+  - [Entity linking](https://spacy.io/api/large-language-models#nel)
+  - [Translation](https://spacy.io/api/large-language-models#translation)
+  - [Raw prompt execution for maximum flexibility](https://spacy.io/api/large-language-models#raw)
   - Soon:
     - Semantic role labeling
-- Easy implementation of **your own functions** via [spaCy's registry](https://spacy.io/api/top-level#registry) for custom prompting, parsing and model integrations
-- Map-reduce approach for splitting prompts too long for LLM's context window and fusing the results back together
+- Easy implementation of **your own functions** via [spaCy's registry](https://spacy.io/api/top-level#registry) for custom prompting, parsing and model integrations. For an example, see [here](https://spacy.io/usage/large-language-models#example-4).
+- [Map-reduce approach](https://spacy.io/api/large-language-models#task-sharding) for splitting prompts too long for LLM's context window and fusing the results back together
 
 ## 🧠 Motivation
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ This package integrates Large Language Models (LLMs) into [spaCy](https://spacy.
   - [Relationship extraction](https://spacy.io/api/large-language-models#rel)
   - [Sentiment analysis](https://spacy.io/api/large-language-models#sentiment)
   - [Span categorization](https://spacy.io/api/large-language-models#spancat)
-  - [Summarization] (https://spacy.io/api/large-language-models#summarization)
+  - [Summarization](https://spacy.io/api/large-language-models#summarization)
   - [Entity linking](https://spacy.io/api/large-language-models#nel)
   - [Translation](https://spacy.io/api/large-language-models#translation)
   - [Raw prompt execution for maximum flexibility](https://spacy.io/api/large-language-models#raw)


### PR DESCRIPTION

## Description
Add more direct links to the various built-in tasks that we provide.

I would perhaps also consider rewriting the external links for the models, to specific links in the API docs on spaCy (where you can often find more information & external points for the models, as well)

### Corresponding documentation PR
NA

### Types of change
readme update

## Checklist
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran all tests in `tests` and `usage_examples/tests`, and all new and existing tests passed. This includes
  - all external tests (i. e. `pytest` ran with `--external`)
  - all tests requiring a GPU (i. e. `pytest` ran with `--gpu`)
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
