### PR TITLE
Add Ollama support

### DIFF
--- a/spacy_llm/models/rest/__init__.py
+++ b/spacy_llm/models/rest/__init__.py
@@ -1,4 +1,4 @@
-from . import anthropic, azure, base, cohere, noop, openai
+from . import anthropic, azure, base, cohere, noop, openai, ollama
 
 __all__ = [
     "anthropic",
@@ -7,4 +7,5 @@ __all__ = [
     "cohere",
     "openai",
     "noop",
+    "ollama",
 ]

--- a/spacy_llm/models/rest/ollama/__init__.py
+++ b/spacy_llm/models/rest/ollama/__init__.py
@@ -1,0 +1,8 @@
+from .model import Endpoints, Ollama
+from .registry import ollama_mistral
+
+__all__ = [
+    "Ollama",
+    "Endpoints", 
+    "ollama_mistral"
+]

--- a/spacy_llm/models/rest/ollama/model.py
+++ b/spacy_llm/models/rest/ollama/model.py
@@ -1,0 +1,80 @@
+import os
+import warnings
+from enum import Enum
+from typing import Any, Dict, Iterable, List, Sized
+
+import requests  # type: ignore[import]
+import srsly  # type: ignore[import]
+from requests import HTTPError
+
+from ..base import REST
+
+
+class Endpoints(str, Enum):
+    GENERATE = "http://localhost:11434/api/generate"
+    EMBEDDINGS = "http://localhost:11434/api/embeddings"
+
+class Ollama(REST):
+    @property
+    def credentials(self) -> Dict[str, str]:
+        # No credentials needed for local Ollama server
+        return {}
+    
+    def _verify_auth(self) -> None:
+        # TODO: Verify connectivity to Ollama server
+        pass
+
+    def __call__(self, prompts: Iterable[Iterable[str]]) -> Iterable[Iterable[str]]:
+        headers = {
+            "Content-Type": "application/json",
+        }
+        all_api_responses: List[List[str]] = []
+
+        for prompts_for_doc in prompts:
+            api_responses: List[str] = []
+            prompts_for_doc = list(prompts_for_doc)
+
+            def _request(json_data: Dict[str, Any]) -> Dict[str, Any]:
+                r = self.retry(
+                    call_method=requests.post,
+                    url=self._endpoint,
+                    headers=headers,
+                    json={**json_data, **self._config, "model": self._name, "stream": False},
+                    timeout=self._max_request_time,
+                )
+                try:
+                    r.raise_for_status()
+                except HTTPError as ex:
+                    res_content = r.text
+                    # Include specific error message in exception.
+                    raise ValueError(
+                        f"Request to Ollama API failed: {res_content}"
+                    ) from ex
+                
+                response = r.json()
+
+                if "error" in response:
+                    if self._strict:
+                        raise ValueError(f"API call failed: {response['error']}.")
+                    else:
+                        assert isinstance(prompts_for_doc, Sized)
+                        return {"error": [response['error']] * len(prompts_for_doc)}
+
+                return response
+
+            for prompt in prompts_for_doc:
+                responses = _request({"prompt": prompt})
+                if "error" in responses:
+                    return responses["error"]
+
+                api_responses.append(responses["response"])
+
+            all_api_responses.append(api_responses)
+
+        return all_api_responses
+
+    @staticmethod
+    def _get_context_lengths() -> Dict[str, int]:
+        return {
+            "mistral": 4096
+        }

--- a/spacy_llm/models/rest/ollama/model.py
+++ b/spacy_llm/models/rest/ollama/model.py
@@ -13,6 +13,7 @@ from ..base import REST
 class Endpoints(str, Enum):
     GENERATE = "http://localhost:11434/api/generate"
     EMBEDDINGS = "http://localhost:11434/api/embeddings"
+    TAGS = "http://localhost:11434/api/tags"
 
 class Ollama(REST):
     @property
@@ -21,8 +22,14 @@ class Ollama(REST):
         return {}
     
     def _verify_auth(self) -> None:
-        # TODO: Verify connectivity to Ollama server
-        pass
+        # Healthcheck: Verify connectivity to Ollama server
+        try:
+            r = requests.get(Endpoints.TAGS.value, timeout=5)
+            r.raise_for_status()
+        except (requests.exceptions.RequestException, HTTPError) as ex:
+            raise ValueError(
+                "Failed to connect to the Ollama server. Please ensure that the server is up and running."
+            ) from ex
 
     def __call__(self, prompts: Iterable[Iterable[str]]) -> Iterable[Iterable[str]]:
         headers = {
@@ -76,5 +83,85 @@ class Ollama(REST):
     @staticmethod
     def _get_context_lengths() -> Dict[str, int]:
         return {
-            "mistral": 4096
+            "llama3": 4096,
+            "phi3": 4096,
+            "wizardlm2": 4096,
+            "mistral": 4096,
+            "gemma": 4096,
+            "mixtral": 47000,
+            "llama2": 4096,
+            "codegemma": 4096,
+            "command-r": 35000,
+            "command-r-plus": 35000,
+            "llava": 4096,
+            "dbrx": 4096,
+            "codellama": 4096,
+            "qwen": 4096,
+            "dolphin-mixtral": 47000,
+            "llama2-uncensored": 4096,
+            "mistral-openorca": 4096,
+            "deepseek-coder": 4096,
+            "phi": 4096,
+            "dolphin-mistral": 47000,
+            "nomic-embed-text": 4096,
+            "nous-hermes2": 4096,
+            "orca-mini": 4096,
+            "llama2-chinese": 4096,
+            "zephyr": 4096,
+            "wizard-vicuna-uncensored": 4096,
+            "openhermes": 4096,
+            "vicuna": 4096,
+            "tinyllama": 4096,
+            "tinydolphin": 4096,
+            "openchat": 4096,
+            "starcoder2": 4096,
+            "wizardcoder": 4096,
+            "stable-code": 4096,
+            "starcoder": 4096,
+            "neural-chat": 4096,
+            "yi": 4096,
+            "phind-codellama": 4096,
+            "starling-lm": 4096,
+            "wizard-math": 4096,
+            "falcon": 4096,
+            "dolphin-phi": 4096,
+            "orca2": 4096,
+            "dolphincoder": 4096,
+            "mxbai-embed-large": 4096,
+            "nous-hermes": 4096,
+            "solar": 4096,
+            "bakllava": 4096,
+            "sqlcoder": 4096,
+            "medllama2": 4096,
+            "nous-hermes2-mixtral": 47000,
+            "wizardlm-uncensored": 4096,
+            "dolphin-llama3": 4096,
+            "codeup": 4096,
+            "stablelm2": 4096,
+            "everythinglm": 16384,
+            "all-minilm": 4096,
+            "samantha-mistral": 4096,
+            "yarn-mistral": 128000,
+            "stable-beluga": 4096,
+            "meditron": 4096,
+            "yarn-llama2": 128000,
+            "deepseek-llm": 4096,
+            "llama-pro": 4096,
+            "magicoder": 4096,
+            "stablelm-zephyr": 4096,
+            "codebooga": 4096,
+            "codeqwen": 4096,
+            "mistrallite": 8192,
+            "wizard-vicuna": 4096,
+            "nexusraven": 4096,
+            "xwinlm": 4096,
+            "goliath": 4096,
+            "open-orca-platypus2": 4096,
+            "wizardlm": 4096,
+            "notux": 4096,
+            "megadolphin": 4096,
+            "duckdb-nsql": 4096,
+            "alfred": 4096,
+            "notus": 4096,
+            "snowflake-arctic-embed": 4096
         }

--- a/spacy_llm/models/rest/ollama/registry.py
+++ b/spacy_llm/models/rest/ollama/registry.py
@@ -6,27 +6,16 @@ from ....registry import registry
 from .model import Endpoints, Ollama
 
 @registry.llm_models("spacy.Ollama.v1")
-def ollama_mistral(
+def ollama_llama3(
     config: Dict[Any, Any] = SimpleFrozenDict(),
-    name: str = "mistral",
+    name: str = "llama3",
     strict: bool = Ollama.DEFAULT_STRICT,
     max_tries: int = Ollama.DEFAULT_MAX_TRIES,
     interval: float = Ollama.DEFAULT_INTERVAL,
     max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
     context_length: int = 4096
 ) -> Ollama:
-    """Returns Ollama instance for 'mistral' model.
-    
-    config (Dict[Any, Any]): LLM config passed on to the model's initialization.
-    name (str): Model name to use. Defaults to 'mistral'. 
-    strict (bool): Whether to raise exception on API errors. Defaults to Ollama.DEFAULT_STRICT.
-    max_tries (int): Max number of API request retries. Defaults to Ollama.DEFAULT_MAX_TRIES. 
-    interval (float): Retry interval in seconds. Defaults to Ollama.DEFAULT_INTERVAL.
-    max_request_time (float): Max API request time in seconds. Defaults to Ollama.DEFAULT_MAX_REQUEST_TIME.
-    context_length (int): Max context length. Defaults to 4096.
-
-    RETURNS (Ollama): Ollama instance for 'mistral' model
-    """
+    """Returns Ollama instance for 'llama3' model."""
     return Ollama(
         name=name,
         endpoint=Endpoints.GENERATE.value,
@@ -37,3 +26,1763 @@ def ollama_mistral(
         max_request_time=max_request_time,
         context_length=context_length
     )
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_phi3(
+    config: Dict[Any, Any] = SimpleFrozenDict(),
+    name: str = "phi3",
+    strict: bool = Ollama.DEFAULT_STRICT,
+    max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+    interval: float = Ollama.DEFAULT_INTERVAL,
+    max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+    context_length: int = 4096
+) -> Ollama:
+    """Returns Ollama instance for 'phi3' model."""
+    return Ollama(
+        name=name,
+        endpoint=Endpoints.GENERATE.value,
+        config=config,
+        strict=strict,
+        max_tries=max_tries,
+        interval=interval,
+        max_request_time=max_request_time,
+        context_length=context_length
+    )
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_wizardlm2(
+    config: Dict[Any, Any] = SimpleFrozenDict(),
+    name: str = "wizardlm2",
+    strict: bool = Ollama.DEFAULT_STRICT,
+    max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+    interval: float = Ollama.DEFAULT_INTERVAL,
+    max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+    context_length: int = 4096
+) -> Ollama:
+    """Returns Ollama instance for 'wizardlm2' model."""
+    return Ollama(
+        name=name,
+        endpoint=Endpoints.GENERATE.value,
+        config=config,
+        strict=strict,
+        max_tries=max_tries,
+        interval=interval,
+        max_request_time=max_request_time,
+        context_length=context_length
+    )
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_mistral(
+    config: Dict[Any, Any] = SimpleFrozenDict(),
+    name: str = "mistral",
+    strict: bool = Ollama.DEFAULT_STRICT,
+    max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+    interval: float = Ollama.DEFAULT_INTERVAL,
+    max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+    context_length: int = 4096
+) -> Ollama:
+    """Returns Ollama instance for 'mistral' model."""
+    return Ollama(
+        name=name,
+        endpoint=Endpoints.GENERATE.value,
+        config=config,
+        strict=strict,
+        max_tries=max_tries,
+        interval=interval,
+        max_request_time=max_request_time,
+        context_length=context_length
+    )
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_gemma(
+    config: Dict[Any, Any] = SimpleFrozenDict(),
+    name: str = "gemma",
+    strict: bool = Ollama.DEFAULT_STRICT,
+    max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+    interval: float = Ollama.DEFAULT_INTERVAL,
+    max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+    context_length: int = 4096
+) -> Ollama:
+    """Returns Ollama instance for 'gemma' model."""
+    return Ollama(
+        name=name,
+        endpoint=Endpoints.GENERATE.value,
+        config=config,
+        strict=strict,
+        max_tries=max_tries,
+        interval=interval,
+        max_request_time=max_request_time,
+        context_length=context_length
+    )
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_mixtral(
+    config: Dict[Any, Any] = SimpleFrozenDict(),
+    name: str = "mixtral",
+    strict: bool = Ollama.DEFAULT_STRICT,
+    max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+    interval: float = Ollama.DEFAULT_INTERVAL,
+    max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+    context_length: int = 47000
+) -> Ollama:
+    """Returns Ollama instance for 'mixtral' model."""
+    return Ollama(
+        name=name,
+        endpoint=Endpoints.GENERATE.value,
+        config=config,
+        strict=strict,
+        max_tries=max_tries,
+        interval=interval,
+        max_request_time=max_request_time,
+        context_length=context_length
+    )
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_llama2(
+    config: Dict[Any, Any] = SimpleFrozenDict(),
+    name: str = "llama2",
+    strict: bool = Ollama.DEFAULT_STRICT,
+    max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+    interval: float = Ollama.DEFAULT_INTERVAL,
+    max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+    context_length: int = 4096
+) -> Ollama:
+    """Returns Ollama instance for 'llama2' model."""
+    return Ollama(
+        name=name,
+        endpoint=Endpoints.GENERATE.value,
+        config=config,
+        strict=strict,
+        max_tries=max_tries,
+        interval=interval,
+        max_request_time=max_request_time,
+        context_length=context_length
+    )
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_codegemma(
+    config: Dict[Any, Any] = SimpleFrozenDict(),
+    name: str = "codegemma",
+    strict: bool = Ollama.DEFAULT_STRICT,
+    max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+    interval: float = Ollama.DEFAULT_INTERVAL,
+    max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+    context_length: int = 4096
+) -> Ollama:
+    """Returns Ollama instance for 'codegemma' model."""
+    return Ollama(
+        name=name,
+        endpoint=Endpoints.GENERATE.value,
+        config=config,
+        strict=strict,
+        max_tries=max_tries,
+        interval=interval,
+        max_request_time=max_request_time,
+        context_length=context_length
+    )
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_command_r(
+    config: Dict[Any, Any] = SimpleFrozenDict(),
+    name: str = "command-r",
+    strict: bool = Ollama.DEFAULT_STRICT,
+    max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+    interval: float = Ollama.DEFAULT_INTERVAL,
+    max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+    context_length: int = 35000
+) -> Ollama:
+    """Returns Ollama instance for 'command-r' model."""
+    return Ollama(
+        name=name,
+        endpoint=Endpoints.GENERATE.value,
+        config=config,
+        strict=strict,
+        max_tries=max_tries,
+        interval=interval,
+        max_request_time=max_request_time,
+        context_length=context_length
+    )
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_command_r_plus(
+    config: Dict[Any, Any] = SimpleFrozenDict(),
+    name: str = "command-r-plus",
+    strict: bool = Ollama.DEFAULT_STRICT,
+    max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+    interval: float = Ollama.DEFAULT_INTERVAL,
+    max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+    context_length: int = 35000
+) -> Ollama:
+    """Returns Ollama instance for 'command-r-plus' model."""
+    return Ollama(
+        name=name,
+        endpoint=Endpoints.GENERATE.value,
+        config=config,
+        strict=strict,
+        max_tries=max_tries,
+        interval=interval,
+        max_request_time=max_request_time,
+        context_length=context_length
+    )
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_llava(
+    config: Dict[Any, Any] = SimpleFrozenDict(),
+    name: str = "llava",
+    strict: bool = Ollama.DEFAULT_STRICT,
+    max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+    interval: float = Ollama.DEFAULT_INTERVAL,
+    max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+    context_length: int = 4096
+) -> Ollama:
+    """Returns Ollama instance for 'llava' model."""
+    return Ollama(
+        name=name,
+        endpoint=Endpoints.GENERATE.value,
+        config=config,
+        strict=strict,
+        max_tries=max_tries,
+        interval=interval,
+        max_request_time=max_request_time,
+        context_length=context_length
+    )
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_dbrx(
+    config: Dict[Any, Any] = SimpleFrozenDict(),
+    name: str = "dbrx",
+    strict: bool = Ollama.DEFAULT_STRICT,
+    max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+    interval: float = Ollama.DEFAULT_INTERVAL,
+    max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+    context_length: int = 4096
+) -> Ollama:
+    """Returns Ollama instance for 'dbrx' model."""
+    return Ollama(
+        name=name,
+        endpoint=Endpoints.GENERATE.value,
+        config=config,
+        strict=strict,
+        max_tries=max_tries,
+        interval=interval,
+        max_request_time=max_request_time,
+        context_length=context_length
+    )
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_codellama(
+    config: Dict[Any, Any] = SimpleFrozenDict(),
+    name: str = "codellama",
+    strict: bool = Ollama.DEFAULT_STRICT,
+    max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+    interval: float = Ollama.DEFAULT_INTERVAL,
+    max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+    context_length: int = 4096
+) -> Ollama:
+    """Returns Ollama instance for 'codellama' model."""
+    return Ollama(
+        name=name,
+        endpoint=Endpoints.GENERATE.value,
+        config=config,
+        strict=strict,
+        max_tries=max_tries,
+        interval=interval,
+        max_request_time=max_request_time,
+        context_length=context_length
+    )
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_qwen(
+    config: Dict[Any, Any] = SimpleFrozenDict(),
+    name: str = "qwen",
+    strict: bool = Ollama.DEFAULT_STRICT,
+    max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+    interval: float = Ollama.DEFAULT_INTERVAL,
+    max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+    context_length: int = 4096
+) -> Ollama:
+    """Returns Ollama instance for 'qwen' model."""
+    return Ollama(
+        name=name,
+        endpoint=Endpoints.GENERATE.value,
+        config=config,
+        strict=strict,
+        max_tries=max_tries,
+        interval=interval,
+        max_request_time=max_request_time,
+        context_length=context_length
+    )
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_dolphin_mixtral(
+    config: Dict[Any, Any] = SimpleFrozenDict(),
+    name: str = "dolphin-mixtral",
+    strict: bool = Ollama.DEFAULT_STRICT,
+    max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+    interval: float = Ollama.DEFAULT_INTERVAL,
+    max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+    context_length: int = 47000
+) -> Ollama:
+    """Returns Ollama instance for 'dolphin-mixtral' model."""
+    return Ollama(
+        name=name,
+        endpoint=Endpoints.GENERATE.value,
+        config=config,
+        strict=strict,
+        max_tries=max_tries,
+        interval=interval,
+        max_request_time=max_request_time,
+        context_length=context_length
+    )
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_llama2_uncensored(
+    config: Dict[Any, Any] = SimpleFrozenDict(),
+    name: str = "llama2-uncensored",
+    strict: bool = Ollama.DEFAULT_STRICT,
+    max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+    interval: float = Ollama.DEFAULT_INTERVAL,
+    max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+    context_length: int = 4096
+) -> Ollama:
+    """Returns Ollama instance for 'llama2-uncensored' model."""
+    return Ollama(
+        name=name,
+        endpoint=Endpoints.GENERATE.value,
+        config=config,
+        strict=strict,
+        max_tries=max_tries,
+        interval=interval,
+        max_request_time=max_request_time,
+        context_length=context_length
+    )
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_mistral_openorca(
+    config: Dict[Any, Any] = SimpleFrozenDict(),
+    name: str = "mistral-openorca",
+    strict: bool = Ollama.DEFAULT_STRICT,
+    max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+    interval: float = Ollama.DEFAULT_INTERVAL,
+    max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+    context_length: int = 4096
+) -> Ollama:
+    """Returns Ollama instance for 'mistral-openorca' model."""
+    return Ollama(
+    name=name,
+    endpoint=Endpoints.GENERATE.value,
+    config=config,
+    strict=strict,
+    max_tries=max_tries,
+    interval=interval,
+    max_request_time=max_request_time,
+    context_length=context_length
+    )
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_deepseek_coder(
+    config: Dict[Any, Any] = SimpleFrozenDict(),
+    name: str = "deepseek-coder",
+    strict: bool = Ollama.DEFAULT_STRICT,
+    max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+    interval: float = Ollama.DEFAULT_INTERVAL,
+    max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+    context_length: int = 4096
+) -> Ollama:
+    """Returns Ollama instance for 'deepseek-coder' model."""
+    return Ollama(
+    name=name,
+    endpoint=Endpoints.GENERATE.value,
+    config=config,
+    strict=strict,
+    max_tries=max_tries,
+    interval=interval,
+    max_request_time=max_request_time,
+    context_length=context_length
+    )
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_phi(
+    config: Dict[Any, Any] = SimpleFrozenDict(),
+    name: str = "phi",
+    strict: bool = Ollama.DEFAULT_STRICT,
+    max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+    interval: float = Ollama.DEFAULT_INTERVAL,
+    max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+    context_length: int = 4096
+) -> Ollama:
+    """Returns Ollama instance for 'phi' model."""
+    return Ollama(
+    name=name,
+    endpoint=Endpoints.GENERATE.value,
+    config=config,
+    strict=strict,
+    max_tries=max_tries,
+    interval=interval,
+    max_request_time=max_request_time,
+    context_length=context_length
+    )
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_dolphin_mistral(
+    config: Dict[Any, Any] = SimpleFrozenDict(),
+    name: str = "dolphin-mistral",
+    strict: bool = Ollama.DEFAULT_STRICT,
+    max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+    interval: float = Ollama.DEFAULT_INTERVAL,
+    max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+    context_length: int = 47000
+) -> Ollama:
+    """Returns Ollama instance for 'dolphin-mistral' model."""
+    return Ollama(
+    name=name,
+    endpoint=Endpoints.GENERATE.value,
+    config=config,
+    strict=strict,
+    max_tries=max_tries,
+    interval=interval,
+    max_request_time=max_request_time,
+    context_length=context_length
+    )
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_nomic_embed_text(
+    config: Dict[Any, Any] = SimpleFrozenDict(),
+    name: str = "nomic-embed-text",
+    strict: bool = Ollama.DEFAULT_STRICT,
+    max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+    interval: float = Ollama.DEFAULT_INTERVAL,
+    max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+    context_length: int = 4096
+) -> Ollama:
+    """Returns Ollama instance for 'nomic-embed-text' model."""
+    return Ollama(
+    name=name,
+    endpoint=Endpoints.GENERATE.value,
+    config=config,
+    strict=strict,
+    max_tries=max_tries,
+    interval=interval,
+    max_request_time=max_request_time,
+    context_length=context_length
+)
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_nous_hermes2(
+   config: Dict[Any, Any] = SimpleFrozenDict(),
+   name: str = "nous-hermes2",
+   strict: bool = Ollama.DEFAULT_STRICT,
+   max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+   interval: float = Ollama.DEFAULT_INTERVAL,
+   max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+   context_length: int = 4096
+) -> Ollama:
+   """Returns Ollama instance for 'nous-hermes2' model."""
+   return Ollama(
+       name=name,
+       endpoint=Endpoints.GENERATE.value,
+       config=config,
+       strict=strict,
+       max_tries=max_tries,
+       interval=interval,
+       max_request_time=max_request_time,
+       context_length=context_length
+   )
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_orca_mini(
+   config: Dict[Any, Any] = SimpleFrozenDict(),
+   name: str = "orca-mini",
+   strict: bool = Ollama.DEFAULT_STRICT,
+   max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+   interval: float = Ollama.DEFAULT_INTERVAL,
+   max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+   context_length: int = 4096
+) -> Ollama:
+   """Returns Ollama instance for 'orca-mini' model."""
+   return Ollama(
+       name=name,
+       endpoint=Endpoints.GENERATE.value,
+       config=config,
+       strict=strict,
+       max_tries=max_tries,
+       interval=interval,
+       max_request_time=max_request_time,
+       context_length=context_length
+   )
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_llama2_chinese(
+   config: Dict[Any, Any] = SimpleFrozenDict(),
+   name: str = "llama2-chinese",
+   strict: bool = Ollama.DEFAULT_STRICT,
+   max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+   interval: float = Ollama.DEFAULT_INTERVAL,
+   max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+   context_length: int = 4096
+) -> Ollama:
+   """Returns Ollama instance for 'llama2-chinese' model."""
+   return Ollama(
+       name=name,
+       endpoint=Endpoints.GENERATE.value,
+       config=config,
+       strict=strict,
+       max_tries=max_tries,
+       interval=interval,
+       max_request_time=max_request_time,
+       context_length=context_length
+   )
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_zephyr(
+   config: Dict[Any, Any] = SimpleFrozenDict(),
+   name: str = "zephyr",
+   strict: bool = Ollama.DEFAULT_STRICT,
+   max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+   interval: float = Ollama.DEFAULT_INTERVAL,
+   max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+   context_length: int = 4096
+) -> Ollama:
+   """Returns Ollama instance for 'zephyr' model."""
+   return Ollama(
+       name=name,
+       endpoint=Endpoints.GENERATE.value,
+       config=config,
+       strict=strict,
+       max_tries=max_tries,
+       interval=interval,
+       max_request_time=max_request_time,
+       context_length=context_length
+   )
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_wizard_vicuna_uncensored(
+   config: Dict[Any, Any] = SimpleFrozenDict(),
+   name: str = "wizard-vicuna-uncensored",
+   strict: bool = Ollama.DEFAULT_STRICT,
+   max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+   interval: float = Ollama.DEFAULT_INTERVAL,
+   max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+   context_length: int = 4096
+) -> Ollama:
+   """Returns Ollama instance for 'wizard-vicuna-uncensored' model."""
+   return Ollama(
+       name=name,
+       endpoint=Endpoints.GENERATE.value,
+       config=config,
+       strict=strict,
+       max_tries=max_tries,
+       interval=interval,
+       max_request_time=max_request_time,
+       context_length=context_length
+   )
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_openhermes(
+   config: Dict[Any, Any] = SimpleFrozenDict(),
+   name: str = "openhermes",
+   strict: bool = Ollama.DEFAULT_STRICT,
+   max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+   interval: float = Ollama.DEFAULT_INTERVAL,
+   max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+   context_length: int = 4096
+) -> Ollama:
+   """Returns Ollama instance for 'openhermes' model."""
+   return Ollama(
+       name=name,
+       endpoint=Endpoints.GENERATE.value,
+       config=config,
+       strict=strict,
+       max_tries=max_tries,
+       interval=interval,
+       max_request_time=max_request_time,
+       context_length=context_length
+   )
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_vicuna(
+   config: Dict[Any, Any] = SimpleFrozenDict(),
+   name: str = "vicuna",
+   strict: bool = Ollama.DEFAULT_STRICT,
+   max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+   interval: float = Ollama.DEFAULT_INTERVAL,
+   max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+   context_length: int = 4096
+) -> Ollama:
+   """Returns Ollama instance for 'vicuna' model."""
+   return Ollama(
+       name=name,
+       endpoint=Endpoints.GENERATE.value,
+       config=config,
+       strict=strict,
+       max_tries=max_tries,
+       interval=interval,
+       max_request_time=max_request_time,
+       context_length=context_length
+   )
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_tinyllama(
+   config: Dict[Any, Any] = SimpleFrozenDict(),
+   name: str = "tinyllama",
+   strict: bool = Ollama.DEFAULT_STRICT,
+   max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+   interval: float = Ollama.DEFAULT_INTERVAL,
+   max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+   context_length: int = 4096
+) -> Ollama:
+   """Returns Ollama instance for 'tinyllama' model."""
+   return Ollama(
+       name=name,
+       endpoint=Endpoints.GENERATE.value,
+       config=config,
+       strict=strict,
+       max_tries=max_tries,
+       interval=interval,
+       max_request_time=max_request_time,
+       context_length=context_length
+   )
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_tinydolphin(
+   config: Dict[Any, Any] = SimpleFrozenDict(),
+   name: str = "tinydolphin",
+   strict: bool = Ollama.DEFAULT_STRICT,
+   max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+   interval: float = Ollama.DEFAULT_INTERVAL,
+   max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+   context_length: int = 4096
+) -> Ollama:
+   """Returns Ollama instance for 'tinydolphin' model."""
+   return Ollama(
+       name=name,
+       endpoint=Endpoints.GENERATE.value,
+       config=config,
+       strict=strict,
+       max_tries=max_tries,
+       interval=interval,
+       max_request_time=max_request_time,
+       context_length=context_length
+   )
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_openchat(
+   config: Dict[Any, Any] = SimpleFrozenDict(),
+   name: str = "openchat",
+   strict: bool = Ollama.DEFAULT_STRICT,
+   max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+   interval: float = Ollama.DEFAULT_INTERVAL,
+   max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+   context_length: int = 4096
+) -> Ollama:
+   """Returns Ollama instance for 'openchat' model."""
+   return Ollama(
+       name=name,
+       endpoint=Endpoints.GENERATE.value,
+       config=config,
+       strict=strict,
+       max_tries=max_tries,
+       interval=interval,
+       max_request_time=max_request_time,
+       context_length=context_length
+   )
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_starcoder2(
+   config: Dict[Any, Any] = SimpleFrozenDict(),
+   name: str = "starcoder2",
+   strict: bool = Ollama.DEFAULT_STRICT,
+   max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+   interval: float = Ollama.DEFAULT_INTERVAL,
+   max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+   context_length: int = 4096
+) -> Ollama:
+   """Returns Ollama instance for 'starcoder2' model."""
+   return Ollama(
+       name=name,
+       endpoint=Endpoints.GENERATE.value,
+       config=config,
+       strict=strict,
+       max_tries=max_tries,
+       interval=interval,
+       max_request_time=max_request_time,
+       context_length=context_length
+   )
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_wizardcoder(
+   config: Dict[Any, Any] = SimpleFrozenDict(),
+   name: str = "wizardcoder",
+   strict: bool = Ollama.DEFAULT_STRICT,
+   max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+   interval: float = Ollama.DEFAULT_INTERVAL,
+   max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+   context_length: int = 4096
+) -> Ollama:
+   """Returns Ollama instance for 'wizardcoder' model."""
+   return Ollama(
+       name=name,
+       endpoint=Endpoints.GENERATE.value,
+       config=config,
+       strict=strict,
+       max_tries=max_tries,
+       interval=interval,
+       max_request_time=max_request_time,
+       context_length=context_length
+   )
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_stable_code(
+   config: Dict[Any, Any] = SimpleFrozenDict(),
+   name: str = "stable-code",
+   strict: bool = Ollama.DEFAULT_STRICT,
+   max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+   interval: float = Ollama.DEFAULT_INTERVAL,
+   max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+   context_length: int = 4096
+) -> Ollama:
+   """Returns Ollama instance for 'stable-code' model."""
+   return Ollama(
+       name=name,
+       endpoint=Endpoints.GENERATE.value,
+       config=config,
+       strict=strict,
+       max_tries=max_tries,
+       interval=interval,
+       max_request_time=max_request_time,
+       context_length=context_length
+   )
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_starcoder(
+   config: Dict[Any, Any] = SimpleFrozenDict(),
+   name: str = "starcoder",
+   strict: bool = Ollama.DEFAULT_STRICT,
+   max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+   interval: float = Ollama.DEFAULT_INTERVAL,
+   max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+   context_length: int = 4096
+) -> Ollama:
+   """Returns Ollama instance for 'starcoder' model."""
+   return Ollama(
+       name=name,
+       endpoint=Endpoints.GENERATE.value,
+       config=config,
+       strict=strict,
+       max_tries=max_tries,
+       interval=interval,
+       max_request_time=max_request_time,
+       context_length=context_length
+   )
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_neural_chat(
+   config: Dict[Any, Any] = SimpleFrozenDict(),
+   name: str = "neural-chat",
+   strict: bool = Ollama.DEFAULT_STRICT,
+   max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+   interval: float = Ollama.DEFAULT_INTERVAL,
+   max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+   context_length: int = 4096
+) -> Ollama:
+   """Returns Ollama instance for 'neural-chat' model."""
+   return Ollama(
+       name=name,
+       endpoint=Endpoints.GENERATE.value,
+       config=config,
+       strict=strict,
+       max_tries=max_tries,
+       interval=interval,
+       max_request_time=max_request_time,
+       context_length=context_length
+   )
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_yi(
+   config: Dict[Any, Any] = SimpleFrozenDict(),
+   name: str = "yi",
+   strict: bool = Ollama.DEFAULT_STRICT,
+   max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+   interval: float = Ollama.DEFAULT_INTERVAL,
+   max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+   context_length: int = 4096
+) -> Ollama:
+   """Returns Ollama instance for 'yi' model."""
+   return Ollama(
+       name=name,
+       endpoint=Endpoints.GENERATE.value,
+       config=config,
+       strict=strict,
+       max_tries=max_tries,
+       interval=interval,
+       max_request_time=max_request_time,
+       context_length=context_length
+   )
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_phind_codellama(
+   config: Dict[Any, Any] = SimpleFrozenDict(),
+   name: str = "phind-codellama",
+   strict: bool = Ollama.DEFAULT_STRICT,
+   max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+   interval: float = Ollama.DEFAULT_INTERVAL,
+   max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+   context_length: int = 4096
+) -> Ollama:
+   """Returns Ollama instance for 'phind-codellama' model."""
+   return Ollama(
+       name=name,
+       endpoint=Endpoints.GENERATE.value,
+       config=config,
+       strict=strict,
+       max_tries=max_tries,
+       interval=interval,
+       max_request_time=max_request_time,
+       context_length=context_length
+   )
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_starling_lm(
+   config: Dict[Any, Any] = SimpleFrozenDict(),
+   name: str = "starling-lm",
+   strict: bool = Ollama.DEFAULT_STRICT,
+   max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+   interval: float = Ollama.DEFAULT_INTERVAL,
+   max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+   context_length: int = 4096
+) -> Ollama:
+   """Returns Ollama instance for 'starling-lm' model."""
+   return Ollama(
+       name=name,
+       endpoint=Endpoints.GENERATE.value,
+       config=config,
+       strict=strict,
+       max_tries=max_tries,
+       interval=interval,
+       max_request_time=max_request_time,
+       context_length=context_length
+   )
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_wizard_math(
+   config: Dict[Any, Any] = SimpleFrozenDict(),
+   name: str = "wizard-math",
+   strict: bool = Ollama.DEFAULT_STRICT,
+   max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+   interval: float = Ollama.DEFAULT_INTERVAL,
+   max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+   context_length: int = 4096
+) -> Ollama:
+   """Returns Ollama instance for 'wizard-math' model."""
+   return Ollama(
+       name=name,
+       endpoint=Endpoints.GENERATE.value,
+       config=config,
+       strict=strict,
+       max_tries=max_tries,
+       interval=interval,
+       max_request_time=max_request_time,
+       context_length=context_length
+   )
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_falcon(
+   config: Dict[Any, Any] = SimpleFrozenDict(),
+   name: str = "falcon",
+   strict: bool = Ollama.DEFAULT_STRICT,
+   max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+   interval: float = Ollama.DEFAULT_INTERVAL,
+   max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+   context_length: int = 4096
+) -> Ollama:
+   """Returns Ollama instance for 'falcon' model."""
+   return Ollama(
+       name=name,
+       endpoint=Endpoints.GENERATE.value,
+       config=config,
+       strict=strict,
+       max_tries=max_tries,
+       interval=interval,
+       max_request_time=max_request_time,
+       context_length=context_length
+   )
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_dolphin_phi(
+   config: Dict[Any, Any] = SimpleFrozenDict(),
+   name: str = "dolphin-phi",
+   strict: bool = Ollama.DEFAULT_STRICT,
+   max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+   interval: float = Ollama.DEFAULT_INTERVAL,
+   max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+   context_length: int = 4096
+) -> Ollama:
+   """Returns Ollama instance for 'dolphin-phi' model."""
+   return Ollama(
+       name=name,
+       endpoint=Endpoints.GENERATE.value,
+       config=config,
+       strict=strict,
+       max_tries=max_tries,
+       interval=interval,
+       max_request_time=max_request_time,
+       context_length=context_length
+   )
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_orca2(
+   config: Dict[Any, Any] = SimpleFrozenDict(),
+   name: str = "orca2",
+   strict: bool = Ollama.DEFAULT_STRICT,
+   max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+   interval: float = Ollama.DEFAULT_INTERVAL,
+   max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+   context_length: int = 4096
+) -> Ollama:
+   """Returns Ollama instance for 'orca2' model."""
+   return Ollama(
+       name=name,
+       endpoint=Endpoints.GENERATE.value,
+       config=config,
+       strict=strict,
+       max_tries=max_tries,
+       interval=interval,
+       max_request_time=max_request_time,
+       context_length=context_length
+   )
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_dolphincoder(
+   config: Dict[Any, Any] = SimpleFrozenDict(),
+   name: str = "dolphincoder",
+   strict: bool = Ollama.DEFAULT_STRICT,
+   max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+   interval: float = Ollama.DEFAULT_INTERVAL,
+   max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+   context_length: int = 4096
+) -> Ollama:
+   """Returns Ollama instance for 'dolphincoder' model."""
+   return Ollama(
+       name=name,
+       endpoint=Endpoints.GENERATE.value,
+       config=config,
+       strict=strict,
+       max_tries=max_tries,
+       interval=interval,
+       max_request_time=max_request_time,
+       context_length=context_length
+   )
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_mxbai_embed_large(
+   config: Dict[Any, Any] = SimpleFrozenDict(),
+   name: str = "mxbai-embed-large",
+   strict: bool = Ollama.DEFAULT_STRICT,
+   max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+   interval: float = Ollama.DEFAULT_INTERVAL,
+   max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+   context_length: int = 4096
+) -> Ollama:
+   """Returns Ollama instance for 'mxbai-embed-large' model."""
+   return Ollama(
+       name=name,
+       endpoint=Endpoints.GENERATE.value,
+       config=config,
+       strict=strict,
+       max_tries=max_tries,
+       interval=interval,
+       max_request_time=max_request_time,
+       context_length=context_length
+   )
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_nous_hermes(
+   config: Dict[Any, Any] = SimpleFrozenDict(),
+   name: str = "nous-hermes",
+   strict: bool = Ollama.DEFAULT_STRICT,
+   max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+   interval: float = Ollama.DEFAULT_INTERVAL,
+   max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+   context_length: int = 4096
+) -> Ollama:
+   """Returns Ollama instance for 'nous-hermes' model."""
+   return Ollama(
+       name=name,
+       endpoint=Endpoints.GENERATE.value,
+       config=config,
+       strict=strict,
+       max_tries=max_tries,
+       interval=interval,
+       max_request_time=max_request_time,
+       context_length=context_length
+   )
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_solar(
+   config: Dict[Any, Any] = SimpleFrozenDict(),
+   name: str = "solar",
+   strict: bool = Ollama.DEFAULT_STRICT,
+   max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+   interval: float = Ollama.DEFAULT_INTERVAL,
+   max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+   context_length: int = 4096
+) -> Ollama:
+   """Returns Ollama instance for 'solar' model."""
+   return Ollama(
+       name=name,
+       endpoint=Endpoints.GENERATE.value,
+       config=config,
+       strict=strict,
+       max_tries=max_tries,
+       interval=interval,
+       max_request_time=max_request_time,
+       context_length=context_length
+   )
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_bakllava(
+   config: Dict[Any, Any] = SimpleFrozenDict(),
+   name: str = "bakllava",
+   strict: bool = Ollama.DEFAULT_STRICT,
+   max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+   interval: float = Ollama.DEFAULT_INTERVAL,
+   max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+   context_length: int = 4096
+) -> Ollama:
+   """Returns Ollama instance for 'bakllava' model."""
+   return Ollama(
+       name=name,
+       endpoint=Endpoints.GENERATE.value,
+       config=config,
+       strict=strict,
+       max_tries=max_tries,
+       interval=interval,
+       max_request_time=max_request_time,
+       context_length=context_length
+   )
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_sqlcoder(
+   config: Dict[Any, Any] = SimpleFrozenDict(),
+   name: str = "sqlcoder",
+   strict: bool = Ollama.DEFAULT_STRICT,
+   max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+   interval: float = Ollama.DEFAULT_INTERVAL,
+   max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+   context_length: int = 4096
+) -> Ollama:
+   """Returns Ollama instance for 'sqlcoder' model."""
+   return Ollama(
+       name=name,
+       endpoint=Endpoints.GENERATE.value,
+       config=config,
+       strict=strict,
+       max_tries=max_tries,
+       interval=interval,
+       max_request_time=max_request_time,
+       context_length=context_length
+   )
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_medllama2(
+   config: Dict[Any, Any] = SimpleFrozenDict(),
+   name: str = "medllama2",
+   strict: bool = Ollama.DEFAULT_STRICT,
+   max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+   interval: float = Ollama.DEFAULT_INTERVAL,
+   max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+   context_length: int = 4096
+) -> Ollama:
+   """Returns Ollama instance for 'medllama2' model."""
+   return Ollama(
+       name=name,
+       endpoint=Endpoints.GENERATE.value,
+       config=config,
+       strict=strict,
+       max_tries=max_tries,
+       interval=interval,
+       max_request_time=max_request_time,
+       context_length=context_length
+   )
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_nous_hermes2_mixtral(
+   config: Dict[Any, Any] = SimpleFrozenDict(),
+   name: str = "nous-hermes2-mixtral",
+   strict: bool = Ollama.DEFAULT_STRICT,
+   max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+   interval: float = Ollama.DEFAULT_INTERVAL,
+   max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+   context_length: int = 47000
+) -> Ollama:
+   """Returns Ollama instance for 'nous-hermes2-mixtral' model."""
+   return Ollama(
+       name=name,
+       endpoint=Endpoints.GENERATE.value,
+       config=config,
+       strict=strict,
+       max_tries=max_tries,
+       interval=interval,
+       max_request_time=max_request_time,
+       context_length=context_length
+   )
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_wizardlm_uncensored(
+   config: Dict[Any, Any] = SimpleFrozenDict(),
+   name: str = "wizardlm-uncensored",
+   strict: bool = Ollama.DEFAULT_STRICT,
+   max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+   interval: float = Ollama.DEFAULT_INTERVAL,
+   max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+   context_length: int = 4096
+) -> Ollama:
+   """Returns Ollama instance for 'wizardlm-uncensored' model."""
+   return Ollama(
+       name=name,
+       endpoint=Endpoints.GENERATE.value,
+       config=config,
+       strict=strict,
+       max_tries=max_tries,
+       interval=interval,
+       max_request_time=max_request_time,
+       context_length=context_length
+   )
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_dolphin_llama3(
+   config: Dict[Any, Any] = SimpleFrozenDict(),
+   name: str = "dolphin-llama3",
+   strict: bool = Ollama.DEFAULT_STRICT,
+   max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+   interval: float = Ollama.DEFAULT_INTERVAL,
+   max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+   context_length: int = 4096
+) -> Ollama:
+   """Returns Ollama instance for 'dolphin-llama3' model."""
+   return Ollama(
+       name=name,
+       endpoint=Endpoints.GENERATE.value,
+       config=config,
+       strict=strict,
+       max_tries=max_tries,
+       interval=interval,
+       max_request_time=max_request_time,
+       context_length=context_length
+   )
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_codeup(
+   config: Dict[Any, Any] = SimpleFrozenDict(),
+   name: str = "codeup",
+   strict: bool = Ollama.DEFAULT_STRICT,
+   max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+   interval: float = Ollama.DEFAULT_INTERVAL,
+   max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+   context_length: int = 4096
+) -> Ollama:
+   """Returns Ollama instance for 'codeup' model."""
+   return Ollama(
+       name=name,
+       endpoint=Endpoints.GENERATE.value,
+       config=config,
+       strict=strict,
+       max_tries=max_tries,
+       interval=interval,
+       max_request_time=max_request_time,
+       context_length=context_length
+   )
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_stablelm2(
+   config: Dict[Any, Any] = SimpleFrozenDict(),
+   name: str = "stablelm2",
+   strict: bool = Ollama.DEFAULT_STRICT,
+   max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+   interval: float = Ollama.DEFAULT_INTERVAL,
+   max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+   context_length: int = 4096
+) -> Ollama:
+   """Returns Ollama instance for 'stablelm2' model."""
+   return Ollama(
+       name=name,
+       endpoint=Endpoints.GENERATE.value,
+       config=config,
+       strict=strict,
+       max_tries=max_tries,
+       interval=interval,
+       max_request_time=max_request_time,
+       context_length=context_length
+   )
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_everythinglm(
+   config: Dict[Any, Any] = SimpleFrozenDict(),
+   name: str = "everythinglm",
+   strict: bool = Ollama.DEFAULT_STRICT,
+   max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+   interval: float = Ollama.DEFAULT_INTERVAL,
+   max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+   context_length: int = 16384
+) -> Ollama:
+   """Returns Ollama instance for 'everythinglm' model."""
+   return Ollama(
+       name=name,
+       endpoint=Endpoints.GENERATE.value,
+       config=config,
+       strict=strict,
+       max_tries=max_tries,
+       interval=interval,
+       max_request_time=max_request_time,
+       context_length=context_length
+   )
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_all_minilm(
+   config: Dict[Any, Any] = SimpleFrozenDict(),
+   name: str = "all-minilm",
+   strict: bool = Ollama.DEFAULT_STRICT,
+   max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+   interval: float = Ollama.DEFAULT_INTERVAL,
+   max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+   context_length: int = 4096
+) -> Ollama:
+   """Returns Ollama instance for 'all-minilm' model."""
+   return Ollama(
+       name=name,
+       endpoint=Endpoints.GENERATE.value,
+       config=config,
+       strict=strict,
+       max_tries=max_tries,
+       interval=interval,
+       max_request_time=max_request_time,
+       context_length=context_length
+   )
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_samantha_mistral(
+   config: Dict[Any, Any] = SimpleFrozenDict(),
+   name: str = "samantha-mistral",
+   strict: bool = Ollama.DEFAULT_STRICT,
+   max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+   interval: float = Ollama.DEFAULT_INTERVAL,
+   max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+   context_length: int = 4096
+) -> Ollama:
+   """Returns Ollama instance for 'samantha-mistral' model."""
+   return Ollama(
+       name=name,
+       endpoint=Endpoints.GENERATE.value,
+       config=config,
+       strict=strict,
+       max_tries=max_tries,
+       interval=interval,
+       max_request_time=max_request_time,
+       context_length=context_length
+   )
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_yarn_mistral(
+   config: Dict[Any, Any] = SimpleFrozenDict(),
+   name: str = "yarn-mistral",
+   strict: bool = Ollama.DEFAULT_STRICT,
+   max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+   interval: float = Ollama.DEFAULT_INTERVAL,
+   max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+   context_length: int = 128000
+) -> Ollama:
+   """Returns Ollama instance for 'yarn-mistral' model."""
+   return Ollama(
+       name=name,
+       endpoint=Endpoints.GENERATE.value,
+       config=config,
+       strict=strict,
+       max_tries=max_tries,
+       interval=interval,
+       max_request_time=max_request_time,
+       context_length=context_length
+   )
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_stable_beluga(
+   config: Dict[Any, Any] = SimpleFrozenDict(),
+   name: str = "stable-beluga",
+   strict: bool = Ollama.DEFAULT_STRICT,
+   max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+   interval: float = Ollama.DEFAULT_INTERVAL,
+   max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+   context_length: int = 4096
+) -> Ollama:
+   """Returns Ollama instance for 'stable-beluga' model."""
+   return Ollama(
+       name=name,
+       endpoint=Endpoints.GENERATE.value,
+       config=config,
+       strict=strict,
+       max_tries=max_tries,
+       interval=interval,
+       max_request_time=max_request_time,
+       context_length=context_length
+   )
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_meditron(
+   config: Dict[Any, Any] = SimpleFrozenDict(),
+   name: str = "meditron",
+   strict: bool = Ollama.DEFAULT_STRICT,
+   max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+   interval: float = Ollama.DEFAULT_INTERVAL,
+   max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+   context_length: int = 4096
+) -> Ollama:
+   """Returns Ollama instance for 'meditron' model."""
+   return Ollama(
+       name=name,
+       endpoint=Endpoints.GENERATE.value,
+       config=config,
+       strict=strict,
+       max_tries=max_tries,
+       interval=interval,
+       max_request_time=max_request_time,
+       context_length=context_length
+   )
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_yarn_llama2(
+   config: Dict[Any, Any] = SimpleFrozenDict(),
+   name: str = "yarn-llama2",
+   strict: bool = Ollama.DEFAULT_STRICT,
+   max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+   interval: float = Ollama.DEFAULT_INTERVAL,
+   max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+   context_length: int = 128000
+) -> Ollama:
+   """Returns Ollama instance for 'yarn-llama2' model."""
+   return Ollama(
+       name=name,
+       endpoint=Endpoints.GENERATE.value,
+       config=config,
+       strict=strict,
+       max_tries=max_tries,
+       interval=interval,
+       max_request_time=max_request_time,
+       context_length=context_length
+   )
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_deepseek_llm(
+   config: Dict[Any, Any] = SimpleFrozenDict(),
+   name: str = "deepseek-llm",
+   strict: bool = Ollama.DEFAULT_STRICT,
+   max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+   interval: float = Ollama.DEFAULT_INTERVAL,
+   max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+   context_length: int = 4096
+) -> Ollama:
+   """Returns Ollama instance for 'deepseek-llm' model."""
+   return Ollama(
+       name=name,
+       endpoint=Endpoints.GENERATE.value,
+       config=config,
+       strict=strict,
+       max_tries=max_tries,
+       interval=interval,
+       max_request_time=max_request_time,
+       context_length=context_length
+   )
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_llama_pro(
+   config: Dict[Any, Any] = SimpleFrozenDict(),
+   name: str = "llama-pro",
+   strict: bool = Ollama.DEFAULT_STRICT,
+   max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+   interval: float = Ollama.DEFAULT_INTERVAL,
+   max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+   context_length: int = 4096
+) -> Ollama:
+   """Returns Ollama instance for 'llama-pro' model."""
+   return Ollama(
+       name=name,
+       endpoint=Endpoints.GENERATE.value,
+       config=config,
+       strict=strict,
+       max_tries=max_tries,
+       interval=interval,
+       max_request_time=max_request_time,
+       context_length=context_length
+   )
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_magicoder(
+   config: Dict[Any, Any] = SimpleFrozenDict(),
+   name: str = "magicoder",
+   strict: bool = Ollama.DEFAULT_STRICT,
+   max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+   interval: float = Ollama.DEFAULT_INTERVAL,
+   max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+   context_length: int = 4096
+) -> Ollama:
+   """Returns Ollama instance for 'magicoder' model."""
+   return Ollama(
+       name=name,
+       endpoint=Endpoints.GENERATE.value,
+       config=config,
+       strict=strict,
+       max_tries=max_tries,
+       interval=interval,
+       max_request_time=max_request_time,
+       context_length=context_length
+   )
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_stablelm_zephyr(
+   config: Dict[Any, Any] = SimpleFrozenDict(),
+   name: str = "stablelm-zephyr",
+   strict: bool = Ollama.DEFAULT_STRICT,
+   max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+   interval: float = Ollama.DEFAULT_INTERVAL,
+   max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+   context_length: int = 4096
+) -> Ollama:
+   """Returns Ollama instance for 'stablelm-zephyr' model."""
+   return Ollama(
+       name=name,
+       endpoint=Endpoints.GENERATE.value,
+       config=config,
+       strict=strict,
+       max_tries=max_tries,
+       interval=interval,
+       max_request_time=max_request_time,
+       context_length=context_length
+   )
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_codebooga(
+   config: Dict[Any, Any] = SimpleFrozenDict(),
+   name: str = "codebooga",
+   strict: bool = Ollama.DEFAULT_STRICT,
+   max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+   interval: float = Ollama.DEFAULT_INTERVAL,
+   max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+   context_length: int = 4096
+) -> Ollama:
+   """Returns Ollama instance for 'codebooga' model."""
+   return Ollama(
+       name=name,
+       endpoint=Endpoints.GENERATE.value,
+       config=config,
+       strict=strict,
+       max_tries=max_tries,
+       interval=interval,
+       max_request_time=max_request_time,
+       context_length=context_length
+   )
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_codeqwen(
+   config: Dict[Any, Any] = SimpleFrozenDict(),
+   name: str = "codeqwen",
+   strict: bool = Ollama.DEFAULT_STRICT,
+   max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+   interval: float = Ollama.DEFAULT_INTERVAL,
+   max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+   context_length: int = 4096
+) -> Ollama:
+   """Returns Ollama instance for 'codeqwen' model."""
+   return Ollama(
+       name=name,
+       endpoint=Endpoints.GENERATE.value,
+       config=config,
+       strict=strict,
+       max_tries=max_tries,
+       interval=interval,
+       max_request_time=max_request_time,
+       context_length=context_length
+   )
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_mistrallite(
+   config: Dict[Any, Any] = SimpleFrozenDict(),
+   name: str = "mistrallite",
+   strict: bool = Ollama.DEFAULT_STRICT,
+   max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+   interval: float = Ollama.DEFAULT_INTERVAL,
+   max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+   context_length: int = 8192
+) -> Ollama:
+   """Returns Ollama instance for 'mistrallite' model."""
+   return Ollama(
+       name=name,
+       endpoint=Endpoints.GENERATE.value,
+       config=config,
+       strict=strict,
+       max_tries=max_tries,
+       interval=interval,
+       max_request_time=max_request_time,
+       context_length=context_length
+   )
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_wizard_vicuna(
+   config: Dict[Any, Any] = SimpleFrozenDict(),
+   name: str = "wizard-vicuna",
+   strict: bool = Ollama.DEFAULT_STRICT,
+   max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+   interval: float = Ollama.DEFAULT_INTERVAL,
+   max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+   context_length: int = 4096
+) -> Ollama:
+   """Returns Ollama instance for 'wizard-vicuna' model."""
+   return Ollama(
+       name=name,
+       endpoint=Endpoints.GENERATE.value,
+       config=config,
+       strict=strict,
+       max_tries=max_tries,
+       interval=interval,
+       max_request_time=max_request_time,
+       context_length=context_length
+   )
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_nexusraven(
+   config: Dict[Any, Any] = SimpleFrozenDict(),
+   name: str = "nexusraven",
+   strict: bool = Ollama.DEFAULT_STRICT,
+   max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+   interval: float = Ollama.DEFAULT_INTERVAL,
+   max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+   context_length: int = 4096
+) -> Ollama:
+   """Returns Ollama instance for 'nexusraven' model."""
+   return Ollama(
+       name=name,
+       endpoint=Endpoints.GENERATE.value,
+       config=config,
+       strict=strict,
+       max_tries=max_tries,
+       interval=interval,
+       max_request_time=max_request_time,
+       context_length=context_length
+   )
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_xwinlm(
+   config: Dict[Any, Any] = SimpleFrozenDict(),
+   name: str = "xwinlm",
+   strict: bool = Ollama.DEFAULT_STRICT,
+   max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+   interval: float = Ollama.DEFAULT_INTERVAL,
+   max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+   context_length: int = 4096
+) -> Ollama:
+   """Returns Ollama instance for 'xwinlm' model."""
+   return Ollama(
+       name=name,
+       endpoint=Endpoints.GENERATE.value,
+       config=config,
+       strict=strict,
+       max_tries=max_tries,
+       interval=interval,
+       max_request_time=max_request_time,
+       context_length=context_length
+   )
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_goliath(
+   config: Dict[Any, Any] = SimpleFrozenDict(),
+   name: str = "goliath",
+   strict: bool = Ollama.DEFAULT_STRICT,
+   max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+   interval: float = Ollama.DEFAULT_INTERVAL,
+   max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+   context_length: int = 4096
+) -> Ollama:
+   """Returns Ollama instance for 'goliath' model."""
+   return Ollama(
+       name=name,
+       endpoint=Endpoints.GENERATE.value,
+       config=config,
+       strict=strict,
+       max_tries=max_tries,
+       interval=interval,
+       max_request_time=max_request_time,
+       context_length=context_length
+   )
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_open_orca_platypus2(
+   config: Dict[Any, Any] = SimpleFrozenDict(),
+   name: str = "open-orca-platypus2",
+   strict: bool = Ollama.DEFAULT_STRICT,
+   max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+   interval: float = Ollama.DEFAULT_INTERVAL,
+   max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+   context_length: int = 4096
+) -> Ollama:
+   """Returns Ollama instance for 'open-orca-platypus2' model."""
+   return Ollama(
+       name=name,
+       endpoint=Endpoints.GENERATE.value,
+       config=config,
+       strict=strict,
+       max_tries=max_tries,
+       interval=interval,
+       max_request_time=max_request_time,
+       context_length=context_length
+   )
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_wizardlm(
+   config: Dict[Any, Any] = SimpleFrozenDict(),
+   name: str = "wizardlm",
+   strict: bool = Ollama.DEFAULT_STRICT,
+   max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+   interval: float = Ollama.DEFAULT_INTERVAL,
+   max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+   context_length: int = 4096
+) -> Ollama:
+   """Returns Ollama instance for 'wizardlm' model."""
+   return Ollama(
+       name=name,
+       endpoint=Endpoints.GENERATE.value,
+       config=config,
+       strict=strict,
+       max_tries=max_tries,
+       interval=interval,
+       max_request_time=max_request_time,
+       context_length=context_length
+   )
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_notux(
+   config: Dict[Any, Any] = SimpleFrozenDict(),
+   name: str = "notux",
+   strict: bool = Ollama.DEFAULT_STRICT,
+   max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+   interval: float = Ollama.DEFAULT_INTERVAL,
+   max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+   context_length: int = 4096
+) -> Ollama:
+   """Returns Ollama instance for 'notux' model."""
+   return Ollama(
+       name=name,
+       endpoint=Endpoints.GENERATE.value,
+       config=config,
+       strict=strict,
+       max_tries=max_tries,
+       interval=interval,
+       max_request_time=max_request_time,
+       context_length=context_length
+   )
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_megadolphin(
+   config: Dict[Any, Any] = SimpleFrozenDict(),
+   name: str = "megadolphin",
+   strict: bool = Ollama.DEFAULT_STRICT,
+   max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+   interval: float = Ollama.DEFAULT_INTERVAL,
+   max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+   context_length: int = 4096
+) -> Ollama:
+   """Returns Ollama instance for 'megadolphin' model."""
+   return Ollama(
+       name=name,
+       endpoint=Endpoints.GENERATE.value,
+       config=config,
+       strict=strict,
+       max_tries=max_tries,
+       interval=interval,
+       max_request_time=max_request_time,
+       context_length=context_length
+   )
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_duckdb_nsql(
+   config: Dict[Any, Any] = SimpleFrozenDict(),
+   name: str = "duckdb-nsql",
+   strict: bool = Ollama.DEFAULT_STRICT,
+   max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+   interval: float = Ollama.DEFAULT_INTERVAL,
+   max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+   context_length: int = 4096
+) -> Ollama:
+   """Returns Ollama instance for 'duckdb-nsql' model."""
+   return Ollama(
+       name=name,
+       endpoint=Endpoints.GENERATE.value,
+       config=config,
+       strict=strict,
+       max_tries=max_tries,
+       interval=interval,
+       max_request_time=max_request_time,
+       context_length=context_length
+   )
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_alfred(
+   config: Dict[Any, Any] = SimpleFrozenDict(),
+   name: str = "alfred",
+   strict: bool = Ollama.DEFAULT_STRICT,
+   max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+   interval: float = Ollama.DEFAULT_INTERVAL,
+   max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+   context_length: int = 4096
+) -> Ollama:
+   """Returns Ollama instance for 'alfred' model."""
+   return Ollama(
+       name=name,
+       endpoint=Endpoints.GENERATE.value,
+       config=config,
+       strict=strict,
+       max_tries=max_tries,
+       interval=interval,
+       max_request_time=max_request_time,
+       context_length=context_length
+   )
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_notus(
+   config: Dict[Any, Any] = SimpleFrozenDict(),
+   name: str = "notus",
+   strict: bool = Ollama.DEFAULT_STRICT,
+   max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+   interval: float = Ollama.DEFAULT_INTERVAL,
+   max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+   context_length: int = 4096
+) -> Ollama:
+   """Returns Ollama instance for 'notus' model."""
+   return Ollama(
+       name=name,
+       endpoint=Endpoints.GENERATE.value,
+       config=config,
+       strict=strict,
+       max_tries=max_tries,
+       interval=interval,
+       max_request_time=max_request_time,
+       context_length=context_length
+   )
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_snowflake_arctic_embed(
+   config: Dict[Any, Any] = SimpleFrozenDict(),
+   name: str = "snowflake-arctic-embed",
+   strict: bool = Ollama.DEFAULT_STRICT,
+   max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+   interval: float = Ollama.DEFAULT_INTERVAL,
+   max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+   context_length: int = 4096
+) -> Ollama:
+   """Returns Ollama instance for 'snowflake-arctic-embed' model."""
+   return Ollama(
+       name=name,
+       endpoint=Endpoints.GENERATE.value,
+       config=config,
+       strict=strict,
+       max_tries=max_tries,
+       interval=interval,
+       max_request_time=max_request_time,
+       context_length=context_length
+   )

--- a/spacy_llm/models/rest/ollama/registry.py
+++ b/spacy_llm/models/rest/ollama/registry.py
@@ -1,0 +1,39 @@
+from typing import Any, Dict
+
+from confection import SimpleFrozenDict
+
+from ....registry import registry
+from .model import Endpoints, Ollama
+
+@registry.llm_models("spacy.Ollama.v1")
+def ollama_mistral(
+    config: Dict[Any, Any] = SimpleFrozenDict(),
+    name: str = "mistral",
+    strict: bool = Ollama.DEFAULT_STRICT,
+    max_tries: int = Ollama.DEFAULT_MAX_TRIES,
+    interval: float = Ollama.DEFAULT_INTERVAL,
+    max_request_time: float = Ollama.DEFAULT_MAX_REQUEST_TIME,
+    context_length: int = 4096
+) -> Ollama:
+    """Returns Ollama instance for 'mistral' model.
+    
+    config (Dict[Any, Any]): LLM config passed on to the model's initialization.
+    name (str): Model name to use. Defaults to 'mistral'. 
+    strict (bool): Whether to raise exception on API errors. Defaults to Ollama.DEFAULT_STRICT.
+    max_tries (int): Max number of API request retries. Defaults to Ollama.DEFAULT_MAX_TRIES. 
+    interval (float): Retry interval in seconds. Defaults to Ollama.DEFAULT_INTERVAL.
+    max_request_time (float): Max API request time in seconds. Defaults to Ollama.DEFAULT_MAX_REQUEST_TIME.
+    context_length (int): Max context length. Defaults to 4096.
+
+    RETURNS (Ollama): Ollama instance for 'mistral' model
+    """
+    return Ollama(
+        name=name,
+        endpoint=Endpoints.GENERATE.value,
+        config=config,
+        strict=strict,
+        max_tries=max_tries,
+        interval=interval,
+        max_request_time=max_request_time,
+        context_length=context_length
+    )


### PR DESCRIPTION
Added Ollama support

## Description
I added support for Ollama which can now be used in conjunction with `spacy-llm`. I added all the models currently supported as well, but perhaps it's better to let users define those themselves? I thought it nicer to just have a set of pre-baked models available...

### Corresponding documentation PR
Docs updates are at https://github.com/explosion/spaCy/pull/13465

### Types of change
feature

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [ ] I ran all tests in `tests` and `usage_examples/tests`, and all new and existing tests passed. This includes
  - all external tests (i. e. `pytest` ran with `--external`)
  - all tests requiring a GPU (i. e. `pytest` ran with `--gpu`)
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
