### PR TITLE
Support for Python 3.12 and update GH actions

### DIFF
--- a/.github/workflows/explosionbot.yml
+++ b/.github/workflows/explosionbot.yml
@@ -15,8 +15,8 @@ jobs:
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
         run: echo "$GITHUB_CONTEXT"
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
       - name: Install and run explosion-bot
         run: |
           pip install git+https://${{ secrets.EXPLOSIONBOT_TOKEN }}@github.com/explosion/explosion-bot

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python_version: ["3.11"]
+        python_version: ["3.12"]
         include:
           - os: windows-latest
             python_version: "3.7"
@@ -32,6 +32,8 @@ jobs:
             python_version: "3.9"
           - os: windows-latest
             python_version: "3.10"
+          - os: macos-latest
+            python_version: "3.11"
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,10 +38,10 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python_version }}
 

--- a/.github/workflows/test_external.yml
+++ b/.github/workflows/test_external.yml
@@ -20,10 +20,10 @@ jobs:
     if: "github.repository_owner == 'explosion' && (contains(github.event.pull_request.labels.*.name, 'Test external') || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')"
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python 3.9
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
           cache: "pip"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -6,9 +6,9 @@ jobs:
   run:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python 3.9
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
           cache: "pip" # caching pip dependencies

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ classifiers =
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Topic :: Scientific/Engineering
 project_urls =
     Release notes = https://github.com/explosion/spacy-llm/releases


### PR DESCRIPTION

## Description
- Add support for Python 3.12
- Bump versions of Github actions to the latest

### Corresponding documentation PR
NA

### Types of change
CI fix

## Checklist
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [] I ran all tests in `tests` and `usage_examples/tests`, and all new and existing tests passed. This includes
  - all external tests (i. e. `pytest` ran with `--external`)
  - all tests requiring a GPU (i. e. `pytest` ran with `--gpu`)
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
