### PR TITLE
Ensure that torch is not used unless it is available

### DIFF
--- a/spacy_llm/models/hf/stablelm.py
+++ b/spacy_llm/models/hf/stablelm.py
@@ -2,11 +2,11 @@ from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple
 
 from confection import SimpleFrozenDict
 
-from ...compat import Literal, has_transformers, torch, transformers
+from ...compat import Literal, has_torch, has_transformers, torch, transformers
 from ...registry.util import registry
 from .base import HuggingFace
 
-if has_transformers:
+if has_transformers and has_torch:
 
     class _StopOnTokens(transformers.StoppingCriteria):
         def __call__(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
Bugfix. If you had `transformers` installed but not `torch`, you would get an ugly error upon importing `spacy_llm`:
```
Traceback (most recent call last):
  File "...\spacy-llm\spacy_llm\__init__.py", line 1, in <module>
    from . import cache  # noqa: F401
  File "...\spacy-llm\spacy_llm\cache.py", line 11, in <module>
    from .ty import PromptTemplateProvider, ShardingLLMTask
  File "...\spacy-llm\spacy_llm\ty.py", line 14, in <module>
    from .models import langchain
  File "...\spacy-llm\spacy_llm\models\__init__.py", line 1, in <module>
    from .hf import dolly_hf, openllama_hf, stablelm_hf
  File "...\spacy-llm\spacy_llm\models\hf\__init__.py", line 7, in <module>
    from .registry import huggingface_v1
  File "...\spacy-llm\spacy_llm\models\hf\registry.py", line 12, in <module>
    from .stablelm import StableLM
  File "...\spacy-llm\spacy_llm\models\hf\stablelm.py", line 11, in <module>
    class _StopOnTokens(transformers.StoppingCriteria):
  File "...\spacy-llm\spacy_llm\models\hf\stablelm.py", line 13, in _StopOnTokens
    self, input_ids: torch.LongTensor, scores: torch.FloatTensor, **kwargs
AttributeError: 'NoneType' object has no attribute 'LongTensor'
```

### Corresponding documentation PR
<!--- Add the link to the corresponding documentation PR here, if applicable. -->

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran all tests in `tests` and `usage_examples/tests`, and all new and existing tests passed. This includes
  - all external tests (i. e. `pytest` ran with `--external`)
  - all tests requiring a GPU (i. e. `pytest` ran with `--gpu`)
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
