### PR TITLE
Added conversational history parameter for openai

### DIFF
--- a/spacy_llm/models/rest/base.py
+++ b/spacy_llm/models/rest/base.py
@@ -1,7 +1,7 @@
 import abc
 import time
 from enum import Enum
-from typing import Any, Callable, Dict, Iterable, Optional
+from typing import Any, Callable, Dict, List, Iterable, Optional
 
 import requests  # type: ignore
 from requests import ConnectTimeout, ReadTimeout
@@ -34,6 +34,7 @@ class REST(abc.ABC):
         interval: float,
         max_request_time: float,
         context_length: Optional[int],
+        conversational_history: Optional[List[Dict[str,str]]]
     ):
         """Initializes new instance of REST-based model.
         name (str): Model name.
@@ -60,6 +61,7 @@ class REST(abc.ABC):
         self._max_request_time = max_request_time
         self._credentials = self.credentials
         self._context_length = context_length
+        self._conversational_history = conversational_history
 
         assert self._max_tries >= 1
         assert self._interval > 0

--- a/spacy_llm/models/rest/base.py
+++ b/spacy_llm/models/rest/base.py
@@ -34,7 +34,7 @@ class REST(abc.ABC):
         interval: float,
         max_request_time: float,
         context_length: Optional[int],
-        conversational_history: Optional[List[Dict[str,str]]]
+        conversational_history: Optional[List[Dict[str,str]]] = None
     ):
         """Initializes new instance of REST-based model.
         name (str): Model name.

--- a/spacy_llm/models/rest/openai/model.py
+++ b/spacy_llm/models/rest/openai/model.py
@@ -125,8 +125,9 @@ class OpenAI(REST):
 
             else:
                 for prompt in prompts_for_doc:
+                    user_message = [{"role": "user", "content": prompt}]
                     responses = _request(
-                        {"messages": [{"role": "user", "content": prompt}]}
+                        {"messages": self._conversational_history + user_message if self._conversational_history else user_message}
                     )
                     if "error" in responses:
                         return responses["error"]

--- a/spacy_llm/models/rest/openai/registry.py
+++ b/spacy_llm/models/rest/openai/registry.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from confection import SimpleFrozenDict
 
@@ -20,6 +20,41 @@ Parameter explanations:
     max_request_time (float): Max. time (in seconds) to wait for request to terminate before raising an exception.
     endpoint (Optional[str]): Endpoint to set. Defaults to standard endpoint.
 """
+
+@registry.llm_models("spacy.GPT-4.v4")
+def openai_gpt_4_v3(
+    config: Dict[Any, Any] = SimpleFrozenDict(temperature=_DEFAULT_TEMPERATURE),
+    name: str = "gpt-4",
+    strict: bool = OpenAI.DEFAULT_STRICT,
+    max_tries: int = OpenAI.DEFAULT_MAX_TRIES,
+    interval: float = OpenAI.DEFAULT_INTERVAL,
+    max_request_time: float = OpenAI.DEFAULT_MAX_REQUEST_TIME,
+    endpoint: Optional[str] = None,
+    context_length: Optional[int] = None,
+    conversational_history: Optional[List[Dict[str,str]]] = None
+) -> OpenAI:
+    """Returns OpenAI instance for 'gpt-4' model using REST to prompt API.
+
+    config (Dict[Any, Any]): LLM config passed on to the model's initialization.
+    name (str): Model name to use. Can be any model name supported by the OpenAI API - e. g. 'gpt-4',
+        "gpt-4-1106-preview", ....
+    conversational_history ( Optional[List[Dict[str,str]]]): Optional conversational history to be provided in the ChatML approach,
+    with the User/Assistant streams to be appended before main prompt request
+    RETURNS (OpenAI): OpenAI instance for 'gpt-4' model.
+
+    DOCS: https://spacy.io/api/large-language-models#models
+    """
+    return OpenAI(
+        name=name,
+        endpoint=endpoint or Endpoints.CHAT.value,
+        config=config,
+        strict=strict,
+        max_tries=max_tries,
+        interval=interval,
+        max_request_time=max_request_time,
+        context_length=context_length,
+        conversational_history=conversational_history
+    )
 
 
 @registry.llm_models("spacy.GPT-4.v3")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. --> Added a parameter to add conversational history supported by openai
which is the ChatML User/Assisant model.
Example:
 [{"role": "user", "content": messge1},
{"role": "assistant", "content": messge2}] is an example of a conversation held by the user and reponse by llm, wich can be appended to the api request to openai

### Corresponding documentation PR
<!--- Add the link to the corresponding documentation PR here, if applicable. -->

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [ ] I confirm that I have the right to submit this contribution under the project's MIT license.
- [ ] I ran all tests in `tests` and `usage_examples/tests`, and all new and existing tests passed. This includes
  - all external tests (i. e. `pytest` ran with `--external`)
  - all tests requiring a GPU (i. e. `pytest` ran with `--gpu`)
- [ ] My changes don't require a change to the documentation, or if they do, I've added all required information.
