### PR TITLE
Fix jinja sandbox

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,9 +25,9 @@ jobs:
         python_version: ["3.12"]
         include:
           - os: windows-latest
-            python_version: "3.7"
+            python_version: "3.9"
           - os: macos-latest
-            python_version: "3.8"
+            python_version: "3.9"
           - os: ubuntu-latest
             python_version: "3.9"
           - os: windows-latest

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-version = 0.7.2
+version = 0.7.3
 description = Integrating LLMs into structured NLP pipelines
 author = Explosion
 author_email = contact@explosion.ai

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,8 +16,6 @@ classifiers =
     Operating System :: MacOS :: MacOS X
     Operating System :: Microsoft :: Windows
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
@@ -30,7 +28,7 @@ project_urls =
 [options]
 zip_safe = false
 include_package_data = true
-python_requires = >=3.7
+python_requires = >=3.9
 install_requires =
     spacy>=3.5,<4.0
     jinja2

--- a/spacy_llm/tasks/builtin_task.py
+++ b/spacy_llm/tasks/builtin_task.py
@@ -64,7 +64,7 @@ class BuiltinTask(abc.ABC):
             prompts in case of multiple shards) and the corresponding shards. The relationship between shard and prompt
             is 1:1.
         """
-        environment = jinja2.Environment()
+        environment = jinja2.SandboxedEnvironment()
         _template = environment.from_string(self._template)
 
         def render_template(shard: Doc, i_shard: int, i_doc: int, n_shards: int) -> str:

--- a/spacy_llm/tasks/builtin_task.py
+++ b/spacy_llm/tasks/builtin_task.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Type, cast
 
 import jinja2
+import jinja2.sandbox
 import srsly
 from spacy import Errors, Language, util
 from spacy.tokens import Doc
@@ -64,7 +65,7 @@ class BuiltinTask(abc.ABC):
             prompts in case of multiple shards) and the corresponding shards. The relationship between shard and prompt
             is 1:1.
         """
-        environment = jinja2.SandboxedEnvironment()
+        environment = jinja2.sandbox.SandboxedEnvironment()
         _template = environment.from_string(self._template)
 
         def render_template(shard: Doc, i_shard: int, i_doc: int, n_shards: int) -> str:


### PR DESCRIPTION
Use sandboxed Jinja environment to ensure loading a foreign config cannot execute code that isn't imported from a library.